### PR TITLE
Update the default port of scripts to use the default port of the manager

### DIFF
--- a/tools/fireeth/scripts/eth-command
+++ b/tools/fireeth/scripts/eth-command
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-port=${MANAGER_API_PORT:-8080}
+port=${MANAGER_API_PORT:-13009}
 
 curl -sS -XGET localhost:$port/v1/start_command

--- a/tools/fireeth/scripts/eth-debug-firehose-logs-30s
+++ b/tools/fireeth/scripts/eth-debug-firehose-logs-30s
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-port=${MANAGER_API_PORT:-8080}
+port=${MANAGER_API_PORT:-13009}
 
 # description: Stop geth for maintenance, start it back with debug deep mind enabled, wait 60s and remove the flag
 curl -sS -XPOST localhost:$port/v1/maintenance?sync=true

--- a/tools/fireeth/scripts/eth-is-running
+++ b/tools/fireeth/scripts/eth-is-running
@@ -1,6 +1,9 @@
 #!/bin/bash
+
+port=${MANAGER_API_PORT:-13009}
+
 # description: prints either 'syncing' if this node is catching up with the network
-if curl localhost:8080/v1/is_running 2> /dev/null | grep -q "true"; then
+if curl localhost:$port/v1/is_running 2> /dev/null | grep -q "true"; then
 	echo Running
 else
 	echo "Not running"

--- a/tools/fireeth/scripts/eth-maintenance
+++ b/tools/fireeth/scripts/eth-maintenance
@@ -1,6 +1,6 @@
 #!/bin/bash
 # description: Stop geth for maintenance
 
-port=${MANAGER_API_PORT:-8080}
+port=${MANAGER_API_PORT:-13009}
 
 curl -sS -XPOST localhost:$port/v1/maintenance?sync=true

--- a/tools/fireeth/scripts/eth-resume
+++ b/tools/fireeth/scripts/eth-resume
@@ -1,6 +1,6 @@
 #!/bin/bash
 # description: Start geth after maintenance
 
-port=${MANAGER_API_PORT:-8080}
+port=${MANAGER_API_PORT:-13009}
 
 curl -sS -XPOST localhost:$port/v1/resume?sync=true

--- a/tools/fireeth/scripts/eth-volume-snapshot
+++ b/tools/fireeth/scripts/eth-volume-snapshot
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Stops geth and take a volumesnapshot of it
 
-port=${MANAGER_API_PORT:-8080}
+port=${MANAGER_API_PORT:-13009}
 
 curl -sS -XPOST localhost:$port/v1/backup?sync=true


### PR DESCRIPTION
The default port for the node manager is not 8080. The scripts should use the [default manager port](https://github.com/streamingfast/firehose-ethereum/blob/437ba16843f9eac54f268ff16dcf27392f313aed/cmd/fireeth/cli/constants.go#L45) instead of 8080.