### PR TITLE
Build in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+
+# NOTE: Inverse glob patterns are only supported in buildkit
+!**/*.go
+!**/go.mod
+!**/go.sum
+
+!tools/fireeth

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,26 +35,16 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.18.8]
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Branch name
         id: extract_branch
@@ -63,8 +53,9 @@ jobs:
           echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
           echo "##[set-output name=release_train;]$(echo ${GITHUB_REF#refs/heads/release/})"
 
-      - name: Build
-        run: go build -v -ldflags "-X main.version=${{ github.event.ref }} -X main.commit=${{ github.sha }} -X main.date=$(date -u +%Y-%m-%dT%H:%MZ)" -o ./fireeth ./cmd/fireeth
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date -u +%Y-%m-%dT%H:%MZ)"
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -93,6 +84,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=build-vanilla
+          cache-to: type=gha,mode=max,scope=build-vanilla
+          build-args: |
+            GO_VERSION=${{ matrix.go-version }}
+            BUILD_VERSION=${{ github.event.ref }}
+            BUILD_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.date.outputs.date }}
 
   bundle-docker-versions:
     needs: build-vanilla
@@ -111,6 +109,7 @@ jobs:
     strategy:
       matrix:
         binary: [geth, bsc, polygon]
+
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,26 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as build
+WORKDIR /build
+
+ARG GO_VERSION=1.18.8
+
+RUN apt-get update && apt-get install curl gcc -y
+RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o go${GO_VERSION}.linux-amd64.tar.gz && \
+       tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+
+ENV PATH "$PATH:/usr/local/go/bin"
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG BUILD_VERSION=local
+ARG BUILD_COMMIT=dev
+ARG BUILD_DATE=1970-01-01T00:00Z
+
+RUN go build -v -ldflags "-X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.date=${BUILD_DATE}" -o ./fireeth ./cmd/fireeth
+
+FROM ubuntu:20.04 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
        apt-get -y install -y \
@@ -8,15 +30,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 RUN rm /etc/localtime && ln -snf /usr/share/zoneinfo/America/Montreal /etc/localtime && dpkg-reconfigure -f noninteractive tzdata
 
-ADD /fireeth /app/fireeth
-
 COPY tools/fireeth/motd_generic /etc/motd
 COPY tools/fireeth/99-fireeth.sh /etc/profile.d/
+
+COPY --from=build /build/fireeth /usr/local/bin/fireeth
 
 # On SSH connection, /root/.bashrc is invoked which invokes '/root/.bash_aliases' if existing,
 # so we hijack the file to "execute" our specialized bash script
 RUN echo ". /etc/profile.d/99-fireeth.sh" > /root/.bash_aliases
 
-ENV PATH "$PATH:/app"
-
-ENTRYPOINT ["/app/fireeth"]
+ENTRYPOINT ["fireeth"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o go${GO_VERSI
 ENV PATH "$PATH:/usr/local/go/bin"
 
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/root/go/pkg/mod \
+RUN --mount=type=cache,id=go-mods,target=/root/go/pkg/mod \
        go mod download
 
 COPY . .
@@ -22,7 +22,7 @@ ARG BUILD_VERSION=local
 ARG BUILD_COMMIT=dev
 ARG BUILD_DATE=1970-01-01T00:00Z
 
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
        go build -v -ldflags "-X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.date=${BUILD_DATE}" -o ./fireeth ./cmd/fireeth
 
 FROM ubuntu:20.04 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# syntax = docker/dockerfile:1.4
+
+# This dockerfile must be built using 'docker buildx build'
 FROM ubuntu:20.04 as build
 WORKDIR /build
 
@@ -10,7 +13,8 @@ RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o go${GO_VERSI
 ENV PATH "$PATH:/usr/local/go/bin"
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/root/go/pkg/mod \
+       go mod download
 
 COPY . .
 
@@ -18,7 +22,8 @@ ARG BUILD_VERSION=local
 ARG BUILD_COMMIT=dev
 ARG BUILD_DATE=1970-01-01T00:00Z
 
-RUN go build -v -ldflags "-X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.date=${BUILD_DATE}" -o ./fireeth ./cmd/fireeth
+RUN --mount=type=cache,target=/root/.cache/go-build \
+       go build -v -ldflags "-X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.date=${BUILD_DATE}" -o ./fireeth ./cmd/fireeth
 
 FROM ubuntu:20.04 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,12 @@ RUN rm /etc/localtime && ln -snf /usr/share/zoneinfo/America/Montreal /etc/local
 COPY tools/fireeth/motd_generic /etc/motd
 COPY tools/fireeth/99-fireeth.sh /etc/profile.d/
 
-COPY --from=build /build/fireeth /usr/local/bin/fireeth
+COPY --from=build /build/fireeth /app/fireeth
 
 # On SSH connection, /root/.bashrc is invoked which invokes '/root/.bash_aliases' if existing,
 # so we hijack the file to "execute" our specialized bash script
 RUN echo ". /etc/profile.d/99-fireeth.sh" > /root/.bash_aliases
 
-ENTRYPOINT ["fireeth"]
+ENV PATH "$PATH:/app"
+
+ENTRYPOINT ["/app/fireeth"]


### PR DESCRIPTION
The `build-vanilla` workflow currently runs the build on the host machine and then loads it into the docker image. This PR changes it so that the build is performed in a build stage within the dockerfile.

Blocked by https://github.com/moby/buildkit/issues/1512

Currently, cache mounts only work in incremental builds (locally) but not in github workflows. Once that's resolved and the build speed is acceptable, this can be considered again.