### PR TITLE
add --latest-block-query to the generic evm poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md)
 for instructions to keep up to date.
 
+## Unreleased
+
+### Added
+
+* Added a `--latest-block-query` flag to the generic evm poller to allow for using either `finalized` or `latest` as parameter when querying for the latest block.
+
 ## v2.3.1
 
 ### Operators

--- a/cmd/fireeth/poller.go
+++ b/cmd/fireeth/poller.go
@@ -92,8 +92,12 @@ func pollerRunE(logger *zap.Logger, tracer logging.Tracer) firecore.CommandExecu
 		poller := blockpoller.New(fetcher, handler, blockpoller.WithStoringState(stateDir), blockpoller.WithLogger(logger))
 
 		latestBlockRef := rpc.FinalizedBlock
-		if blockQuery, err := sflags.GetString(cmd, "latest-block-query"); err == nil && blockQuery == "latest" {
-			latestBlockRef = rpc.LatestBlock
+		if blockQuery, err := sflags.GetString(cmd, "latest-block-query"); err == nil {
+			if blockQuery == "latest" {
+				latestBlockRef = rpc.LatestBlock
+			} else if blockQuery != "finalized" {
+				return fmt.Errorf("invalid value given for the --latest-block-query flag: %q", blockQuery)
+			}
 		}
 
 		latestBlock, err := rpcClient.GetBlockByNumber(ctx, latestBlockRef)


### PR DESCRIPTION
Allows users to specify whether the latest block used by the generic evm poller should be queried using the `finalized` or `latest` parameter. Default is `finalized`.

Implements https://github.com/streamingfast/firehose-core/issues/33