### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/codec/console_reader.go
+++ b/codec/console_reader.go
@@ -1746,7 +1746,7 @@ func (ctx *parseCtx) getCall(indexString string, allowRoot bool, tag string) (*p
 	return ctx.currentTrace.Calls[idx-1], nil
 }
 
-// splitInChunks split the line in chunks and returns the slice `chunks[1:]`, but verifies
+// SplitInChunks split the line in chunks and returns the slice `chunks[1:]`, but verifies
 // that there are only exactly one of `validCounts` number of chunks
 func SplitInChunks(line string, validCounts ...int) ([]string, error) {
 	chunks := strings.SplitN(line, " ", -1)

--- a/substreams/rpccalls.go
+++ b/substreams/rpccalls.go
@@ -201,7 +201,7 @@ func (e *RPCEngine) validateCalls(calls *pbethss.RpcCalls) (err error) {
 
 var evmExecutionExecutionTimeoutRegex = regexp.MustCompile(`execution aborted \(timeout\s*=\s*[^\)]+\)`)
 
-// rpcsCalls performs the RPC calls retrying forever on error if `retryCount` is set to -1. If `retryCount`
+// rpcCalls performs the RPC calls retrying forever on error if `retryCount` is set to -1. If `retryCount`
 // is sets to 0, no retry is attempted. If `retryCount` is > 0, it will retry `retryCount` times.
 //
 // If there is no retry or if partial retry, deterministic will be always `false`. Otherwise, it can only


### PR DESCRIPTION
 fix some function names in comment