### PR TITLE
DEV: Polling for firehose block

### DIFF
--- a/blockfetcher/tracer_fetcher.go
+++ b/blockfetcher/tracer_fetcher.go
@@ -1,0 +1,87 @@
+package blockfetcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	"github.com/streamingfast/eth-go/rpc"
+	"github.com/streamingfast/firehose-ethereum/block"
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"time"
+)
+
+type TracerBlockFetcher struct {
+	fetcher *BlockFetcher
+}
+
+func (f *TracerBlockFetcher) IsBlockAvailable(requested uint64) bool {
+	return f.fetcher.IsBlockAvailable(requested)
+}
+
+func (f *TracerBlockFetcher) Fetch(ctx context.Context, client *rpc.Client, blkNum uint64) (b *pbbstream.Block, skipped bool, err error) {
+	respStr, err := client.DoRequest(ctx, "debug_traceFirehoseBlockByNumber", []interface{}{fmt.Sprintf("0x%x", blkNum), nil})
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to trace block %d: %w", blkNum, err)
+	}
+
+	// The response is base64-encoded
+	lineBytes, err := base64.StdEncoding.DecodeString(respStr)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to decode base64 response for block %d: %w", blkNum, err)
+	}
+	lineBytes = bytes.TrimRight(lineBytes, "\n")
+	lastSpace := bytes.LastIndexByte(lineBytes, ' ')
+	if lastSpace == -1 {
+		return nil, false, fmt.Errorf("invalid firehose block line for block %d", blkNum)
+	}
+	blockBase64 := lineBytes[lastSpace+1:]
+
+	blockData, err := base64.StdEncoding.DecodeString(string(blockBase64))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to decode block payload for block %d: %w", blkNum, err)
+	}
+
+	ethBlock := &pbeth.Block{}
+	if err := proto.Unmarshal(blockData, ethBlock); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal traced block %d: %w", blkNum, err)
+	}
+
+	payload, err := anypb.New(ethBlock)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to wrap block %d: %w", blkNum, err)
+	}
+
+	bstreamBlock := &pbbstream.Block{
+		Number:    ethBlock.Number,
+		Id:        ethBlock.GetFirehoseBlockID(),
+		ParentId:  ethBlock.GetFirehoseBlockParentID(),
+		Timestamp: timestamppb.New(ethBlock.GetFirehoseBlockTime()),
+		LibNum:    ethBlockLIBNum(ethBlock),
+		ParentNum: ethBlock.GetFirehoseBlockParentNumber(),
+		Payload:   payload,
+	}
+
+	return bstreamBlock, false, nil
+}
+
+func NewTracerBlockFetcher(intervalBetweenFetch time.Duration,
+	latestBlockRetryInterval time.Duration,
+	parallelTrxWorkers int,
+	allowEmptyReceiptsOnBlock0 bool,
+	logger *zap.Logger) *TracerBlockFetcher {
+	fetcher := NewBlockFetcher(intervalBetweenFetch, latestBlockRetryInterval, parallelTrxWorkers, block.RpcToEthBlock, logger)
+	if allowEmptyReceiptsOnBlock0 {
+		fetcher.allowEmptyReceiptsOnBlock0 = true
+	}
+	return &TracerBlockFetcher{
+		fetcher: fetcher,
+	}
+}
+
+func (f *TracerBlockFetcher) PollingInterval() time.Duration { return 5 * time.Second }

--- a/blockfetcher/tracer_fetcher.go
+++ b/blockfetcher/tracer_fetcher.go
@@ -1,7 +1,6 @@
 package blockfetcher
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"strings"
 	"time"
 )
 
@@ -30,19 +30,19 @@ func (f *TracerBlockFetcher) Fetch(ctx context.Context, client *rpc.Client, blkN
 		return nil, false, fmt.Errorf("failed to trace block %d: %w", blkNum, err)
 	}
 
-	// The response is base64-encoded
-	lineBytes, err := base64.StdEncoding.DecodeString(respStr)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to decode base64 response for block %d: %w", blkNum, err)
+	// Parse the response string
+	if len(respStr) > 1 && respStr[0] == '"' && respStr[len(respStr)-1] == '"' {
+		respStr = respStr[1 : len(respStr)-1]
 	}
-	lineBytes = bytes.TrimRight(lineBytes, "\n")
-	lastSpace := bytes.LastIndexByte(lineBytes, ' ')
+	respStr = strings.TrimSuffix(respStr, "\n")
+	lastSpace := strings.LastIndex(respStr, " ")
 	if lastSpace == -1 {
 		return nil, false, fmt.Errorf("invalid firehose block line for block %d", blkNum)
 	}
-	blockBase64 := lineBytes[lastSpace+1:]
+	blockBase64 := respStr[lastSpace+1:]
 
-	blockData, err := base64.StdEncoding.DecodeString(string(blockBase64))
+	// Decode payload
+	blockData, err := base64.StdEncoding.DecodeString(blockBase64)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to decode block payload for block %d: %w", blkNum, err)
 	}

--- a/blockfetcher/tracer_fetcher.go
+++ b/blockfetcher/tracer_fetcher.go
@@ -2,17 +2,12 @@ package blockfetcher
 
 import (
 	"context"
-	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
 	"github.com/streamingfast/eth-go/rpc"
 	"github.com/streamingfast/firehose-ethereum/block"
-	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/timestamppb"
-	"strings"
 	"time"
 )
 
@@ -30,64 +25,12 @@ func (f *TracerBlockFetcher) Fetch(ctx context.Context, client *rpc.Client, blkN
 		return nil, false, fmt.Errorf("failed to trace block %d: %w", blkNum, err)
 	}
 
-	// Remove surrounding quotes
-	if len(respStr) > 1 && respStr[0] == '"' && respStr[len(respStr)-1] == '"' {
-		respStr = respStr[1 : len(respStr)-1]
+	var tracedBlock *pbbstream.Block
+	if err := json.Unmarshal([]byte(respStr), &tracedBlock); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal traced block JSON for block %d: %w", blkNum, err)
 	}
 
-	decodedBytes, err := base64.StdEncoding.DecodeString(respStr)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to decode base64: %w", err)
-	}
-
-	decodedStr := string(decodedBytes)
-	lines := strings.Split(decodedStr, "\n")
-
-	var fireBlockLine string
-	for _, line := range lines {
-		if strings.HasPrefix(line, "FIRE BLOCK") {
-			fireBlockLine = line
-			break
-		}
-	}
-
-	if fireBlockLine == "" {
-		return nil, false, fmt.Errorf("no FIRE BLOCK line found in block %d", blkNum)
-	}
-
-	// Extract the base-64 encoded protobuf block
-	fields := strings.Fields(fireBlockLine)
-	if len(fields) < 7 {
-		return nil, false, fmt.Errorf("malformed FIRE BLOCK line in block %d", blkNum)
-	}
-
-	blockPayloadB64 := fields[len(fields)-1]
-	blockBytes, err := base64.StdEncoding.DecodeString(blockPayloadB64)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to decode FIRE BLOCK payload: %w", err)
-	}
-
-	ethBlock := &pbeth.Block{}
-	if err := proto.Unmarshal(blockBytes, ethBlock); err != nil {
-		return nil, false, fmt.Errorf("failed to unmarshal protobuf block for block %d: %w", blkNum, err)
-	}
-
-	payload, err := anypb.New(ethBlock)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to wrap block %d: %w", blkNum, err)
-	}
-
-	bstreamBlock := &pbbstream.Block{
-		Number:    ethBlock.Number,
-		Id:        ethBlock.GetFirehoseBlockID(),
-		ParentId:  ethBlock.GetFirehoseBlockParentID(),
-		Timestamp: timestamppb.New(ethBlock.GetFirehoseBlockTime()),
-		LibNum:    ethBlockLIBNum(ethBlock),
-		ParentNum: ethBlock.GetFirehoseBlockParentNumber(),
-		Payload:   payload,
-	}
-
-	return bstreamBlock, false, nil
+	return tracedBlock, false, nil
 }
 
 func NewTracerBlockFetcher(intervalBetweenFetch time.Duration,

--- a/blockfetcher/tracer_fetcher.go
+++ b/blockfetcher/tracer_fetcher.go
@@ -30,26 +30,46 @@ func (f *TracerBlockFetcher) Fetch(ctx context.Context, client *rpc.Client, blkN
 		return nil, false, fmt.Errorf("failed to trace block %d: %w", blkNum, err)
 	}
 
-	// Parse the response string
+	// Remove surrounding quotes
 	if len(respStr) > 1 && respStr[0] == '"' && respStr[len(respStr)-1] == '"' {
 		respStr = respStr[1 : len(respStr)-1]
 	}
-	respStr = strings.TrimSuffix(respStr, "\n")
-	lastSpace := strings.LastIndex(respStr, " ")
-	if lastSpace == -1 {
-		return nil, false, fmt.Errorf("invalid firehose block line for block %d", blkNum)
-	}
-	blockBase64 := respStr[lastSpace+1:]
 
-	// Decode payload
-	blockData, err := base64.StdEncoding.DecodeString(blockBase64)
+	decodedBytes, err := base64.StdEncoding.DecodeString(respStr)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to decode block payload for block %d: %w", blkNum, err)
+		return nil, false, fmt.Errorf("failed to decode base64: %w", err)
+	}
+
+	decodedStr := string(decodedBytes)
+	lines := strings.Split(decodedStr, "\n")
+
+	var fireBlockLine string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "FIRE BLOCK") {
+			fireBlockLine = line
+			break
+		}
+	}
+
+	if fireBlockLine == "" {
+		return nil, false, fmt.Errorf("no FIRE BLOCK line found in block %d", blkNum)
+	}
+
+	// Extract the base-64 encoded protobuf block
+	fields := strings.Fields(fireBlockLine)
+	if len(fields) < 7 {
+		return nil, false, fmt.Errorf("malformed FIRE BLOCK line in block %d", blkNum)
+	}
+
+	blockPayloadB64 := fields[len(fields)-1]
+	blockBytes, err := base64.StdEncoding.DecodeString(blockPayloadB64)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to decode FIRE BLOCK payload: %w", err)
 	}
 
 	ethBlock := &pbeth.Block{}
-	if err := proto.Unmarshal(blockData, ethBlock); err != nil {
-		return nil, false, fmt.Errorf("failed to unmarshal traced block %d: %w", blkNum, err)
+	if err := proto.Unmarshal(blockBytes, ethBlock); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal protobuf block for block %d: %w", blkNum, err)
 	}
 
 	payload, err := anypb.New(ethBlock)

--- a/cmd/fireeth/poller.go
+++ b/cmd/fireeth/poller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/streamingfast/cli"
 	"path"
 	"strconv"
 	"strings"
@@ -78,8 +79,17 @@ func newFirehoseTracerPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobr
 	cmd := &cobra.Command{
 		Use:   "firehose-tracer-api <rpc-endpoint> <first-streamable-block>",
 		Short: "poll blocks using debug_traceFirehoseBlockByNumber",
-		Args:  cobra.ExactArgs(2),
-		RunE:  pollerRunEForTracer(logger),
+		Long: cli.Dedent(`
+			This poller connects to a Firehose-enabled RPC endpoint and fetches
+			blocks using the "debug_traceFirehoseBlockByNumber" method. It retrieves the
+			full Firehose block data along with execution traces, enabling advanced debugging
+			and block-level analysis.
+
+			*Experimental*: This tool is not production-ready. Intended for development
+			and debugging purposes only. 
+		`),
+		Args: cobra.ExactArgs(2),
+		RunE: pollerRunEForTracer(logger),
 	}
 	cmd.Flags().Duration("interval-between-fetch", 0, "interval between fetch")
 	cmd.Flags().Duration("max-block-fetch-duration", 5*time.Second, "maximum delay before retrying a block fetch")

--- a/cmd/fireeth/poller.go
+++ b/cmd/fireeth/poller.go
@@ -1,15 +1,7 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/base64"
-	"encoding/hex"
 	"fmt"
-	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
-	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"path"
 	"strconv"
 	"strings"
@@ -96,6 +88,14 @@ func newFirehoseTracerPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobr
 }
 
 func pollerRunE(logger *zap.Logger, tracer logging.Tracer) firecore.CommandExecutor {
+	return pollerRunEInternal(logger, tracer, false)
+}
+
+func pollerRunEForTracer(logger *zap.Logger) func(cmd *cobra.Command, args []string) error {
+	return pollerRunEInternal(logger, nil, true)
+}
+
+func pollerRunEInternal(logger *zap.Logger, tracer logging.Tracer, useTracer bool) firecore.CommandExecutor {
 	return func(cmd *cobra.Command, args []string) (err error) {
 		rpcEndpoint := args[0]
 		//dataDir := cmd.Flag("data-dir").Value.String()
@@ -133,7 +133,12 @@ func pollerRunE(logger *zap.Logger, tracer logging.Tracer) firecore.CommandExecu
 
 		rpcClients.Add(rpc.NewClient(rpcEndpoint, opts...))
 
-		fetcher := blockfetcher.NewGenericBlockFetcher(fetchInterval, 1*time.Second, parallelWorkers, sflags.MustGetBool(cmd, "allow-empty-receipts-on-block-0"), logger)
+		var fetcher blockpoller.BlockFetcher[*rpc.Client]
+		if useTracer {
+			fetcher = blockfetcher.NewTracerBlockFetcher(fetchInterval, 1*time.Second, parallelWorkers, sflags.MustGetBool(cmd, "allow-empty-receipts-on-block-0"), logger)
+		} else {
+			fetcher = blockfetcher.NewGenericBlockFetcher(fetchInterval, 1*time.Second, parallelWorkers, sflags.MustGetBool(cmd, "allow-empty-receipts-on-block-0"), logger)
+		}
 		handler := blockpoller.NewFireBlockHandler("type.googleapis.com/sf.ethereum.type.v2.Block")
 		poller := blockpoller.New[*rpc.Client](fetcher, handler, rpcClients, blockpoller.WithStoringState[*rpc.Client](stateDir), blockpoller.WithLogger[*rpc.Client](logger))
 
@@ -143,114 +148,5 @@ func pollerRunE(logger *zap.Logger, tracer logging.Tracer) firecore.CommandExecu
 		}
 
 		return nil
-	}
-}
-
-func pollerRunEForTracer(logger *zap.Logger) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		rpcEndpoint := args[0]
-		firstBlock, err := strconv.ParseUint(args[1], 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid block number: %w", err)
-		}
-
-		// Get flag values
-		intervalBetweenFetch := sflags.MustGetDuration(cmd, "interval-between-fetch")
-		maxBlockFetchDuration := sflags.MustGetDuration(cmd, "max-block-fetch-duration")
-
-		// Connect to the RPC endpoint
-		rpcClient := rpc.NewClient(rpcEndpoint)
-
-		handler := blockpoller.NewFireBlockHandler("type.googleapis.com/sf.ethereum.type.v2.Block")
-
-		for blockNum := firstBlock; ; blockNum++ {
-			select {
-			case <-cmd.Context().Done():
-				return nil
-			default:
-			}
-
-			// Create context with timeout for the RPC call
-			ctx, cancel := context.WithTimeout(cmd.Context(), maxBlockFetchDuration)
-
-			// Make the RPC call to trace the block
-			respStr, err := rpcClient.DoRequest(ctx, "debug_traceFirehoseBlockByNumber", []interface{}{fmt.Sprintf("0x%x", blockNum), nil})
-			cancel()
-
-			if err != nil {
-				logger.Warn("failed to trace block", zap.Uint64("block", blockNum), zap.Error(err))
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			// The response is base64-encoded, not hex-encoded
-			// First decode the base64 response
-			rawBytes, err := base64.StdEncoding.DecodeString(respStr)
-			if err != nil {
-				logger.Warn("failed to decode base64 response", zap.Uint64("block", blockNum), zap.Error(err))
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			// Remove trailing newline if present
-			if len(rawBytes) > 0 && rawBytes[len(rawBytes)-1] == '\n' {
-				rawBytes = rawBytes[:len(rawBytes)-1]
-			}
-
-			// Find the last space to separate the firehose line from the block data
-			lastSpace := bytes.LastIndexByte(rawBytes, ' ')
-			if lastSpace == -1 {
-				logger.Warn("invalid firehose block line", zap.Uint64("block", blockNum))
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			// The part after the last space is the base64-encoded block data
-			base64Part := rawBytes[lastSpace+1:]
-			blockData := make([]byte, base64.StdEncoding.DecodedLen(len(base64Part)))
-			n, err := base64.StdEncoding.Decode(blockData, base64Part)
-			if err != nil {
-				logger.Warn("failed to base64 decode block", zap.Uint64("block", blockNum), zap.Error(err))
-				time.Sleep(1 * time.Second)
-				continue
-			}
-			blockData = blockData[:n]
-
-			block := &pbeth.Block{}
-			if err := proto.Unmarshal(blockData, block); err != nil {
-				logger.Warn("failed to unmarshal traced block", zap.Uint64("block", blockNum), zap.Error(err))
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			blockBytes, err := proto.Marshal(block)
-			if err != nil {
-				logger.Warn("failed to marshal block", zap.Uint64("block", blockNum), zap.Error(err))
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			bstreamBlock := &pbbstream.Block{
-				Number:    block.Number,
-				Id:        hex.EncodeToString(block.Hash),
-				ParentNum: block.Number - 1,
-				ParentId:  hex.EncodeToString(block.Header.ParentHash),
-				LibNum:    0,
-				Timestamp: block.Header.Timestamp,
-				Payload: &anypb.Any{
-					TypeUrl: "type.googleapis.com/sf.ethereum.type.v2.Block",
-					Value:   blockBytes,
-				},
-			}
-
-			if err := handler.Handle(bstreamBlock); err != nil {
-				return fmt.Errorf("failed to handle block: %w", err)
-			}
-
-			// Apply interval between fetches if specified
-			if intervalBetweenFetch > 0 {
-				time.Sleep(intervalBetweenFetch)
-			}
-		}
 	}
 }

--- a/cmd/fireeth/poller.go
+++ b/cmd/fireeth/poller.go
@@ -1,7 +1,15 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"path"
 	"strconv"
 	"strings"
@@ -31,6 +39,7 @@ func newPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	cmd.AddCommand(newOptimismPollerCmd(logger, tracer))
 	cmd.AddCommand(newArbOnePollerCmd(logger, tracer))
 	cmd.AddCommand(newGenericEVMPollerCmd(logger, tracer))
+	cmd.AddCommand(newFirehoseTracerPollerCmd(logger, tracer))
 	return cmd
 }
 
@@ -66,6 +75,19 @@ func newGenericEVMPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Co
 		Short: "poll blocks from a generic EVM RPC endpoint",
 		Args:  cobra.ExactArgs(2),
 		RunE:  pollerRunE(logger, tracer),
+	}
+	cmd.Flags().Duration("interval-between-fetch", 0, "interval between fetch")
+	cmd.Flags().Duration("max-block-fetch-duration", 5*time.Second, "maximum delay before retrying a block fetch")
+
+	return cmd
+}
+
+func newFirehoseTracerPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "firehose-tracer-api <rpc-endpoint> <first-streamable-block>",
+		Short: "poll blocks using debug_traceFirehoseBlockByNumber",
+		Args:  cobra.ExactArgs(2),
+		RunE:  pollerRunEForTracer(logger),
 	}
 	cmd.Flags().Duration("interval-between-fetch", 0, "interval between fetch")
 	cmd.Flags().Duration("max-block-fetch-duration", 5*time.Second, "maximum delay before retrying a block fetch")
@@ -121,5 +143,114 @@ func pollerRunE(logger *zap.Logger, tracer logging.Tracer) firecore.CommandExecu
 		}
 
 		return nil
+	}
+}
+
+func pollerRunEForTracer(logger *zap.Logger) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		rpcEndpoint := args[0]
+		firstBlock, err := strconv.ParseUint(args[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid block number: %w", err)
+		}
+
+		// Get flag values
+		intervalBetweenFetch := sflags.MustGetDuration(cmd, "interval-between-fetch")
+		maxBlockFetchDuration := sflags.MustGetDuration(cmd, "max-block-fetch-duration")
+
+		// Connect to the RPC endpoint
+		rpcClient := rpc.NewClient(rpcEndpoint)
+
+		handler := blockpoller.NewFireBlockHandler("type.googleapis.com/sf.ethereum.type.v2.Block")
+
+		for blockNum := firstBlock; ; blockNum++ {
+			select {
+			case <-cmd.Context().Done():
+				return nil
+			default:
+			}
+
+			// Create context with timeout for the RPC call
+			ctx, cancel := context.WithTimeout(cmd.Context(), maxBlockFetchDuration)
+
+			// Make the RPC call to trace the block
+			respStr, err := rpcClient.DoRequest(ctx, "debug_traceFirehoseBlockByNumber", []interface{}{fmt.Sprintf("0x%x", blockNum), nil})
+			cancel()
+
+			if err != nil {
+				logger.Warn("failed to trace block", zap.Uint64("block", blockNum), zap.Error(err))
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			// The response is base64-encoded, not hex-encoded
+			// First decode the base64 response
+			rawBytes, err := base64.StdEncoding.DecodeString(respStr)
+			if err != nil {
+				logger.Warn("failed to decode base64 response", zap.Uint64("block", blockNum), zap.Error(err))
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			// Remove trailing newline if present
+			if len(rawBytes) > 0 && rawBytes[len(rawBytes)-1] == '\n' {
+				rawBytes = rawBytes[:len(rawBytes)-1]
+			}
+
+			// Find the last space to separate the firehose line from the block data
+			lastSpace := bytes.LastIndexByte(rawBytes, ' ')
+			if lastSpace == -1 {
+				logger.Warn("invalid firehose block line", zap.Uint64("block", blockNum))
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			// The part after the last space is the base64-encoded block data
+			base64Part := rawBytes[lastSpace+1:]
+			blockData := make([]byte, base64.StdEncoding.DecodedLen(len(base64Part)))
+			n, err := base64.StdEncoding.Decode(blockData, base64Part)
+			if err != nil {
+				logger.Warn("failed to base64 decode block", zap.Uint64("block", blockNum), zap.Error(err))
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			blockData = blockData[:n]
+
+			block := &pbeth.Block{}
+			if err := proto.Unmarshal(blockData, block); err != nil {
+				logger.Warn("failed to unmarshal traced block", zap.Uint64("block", blockNum), zap.Error(err))
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			blockBytes, err := proto.Marshal(block)
+			if err != nil {
+				logger.Warn("failed to marshal block", zap.Uint64("block", blockNum), zap.Error(err))
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			bstreamBlock := &pbbstream.Block{
+				Number:    block.Number,
+				Id:        hex.EncodeToString(block.Hash),
+				ParentNum: block.Number - 1,
+				ParentId:  hex.EncodeToString(block.Header.ParentHash),
+				LibNum:    0,
+				Timestamp: block.Header.Timestamp,
+				Payload: &anypb.Any{
+					TypeUrl: "type.googleapis.com/sf.ethereum.type.v2.Block",
+					Value:   blockBytes,
+				},
+			}
+
+			if err := handler.Handle(bstreamBlock); err != nil {
+				return fmt.Errorf("failed to handle block: %w", err)
+			}
+
+			// Apply interval between fetches if specified
+			if intervalBetweenFetch > 0 {
+				time.Sleep(intervalBetweenFetch)
+			}
+		}
 	}
 }


### PR DESCRIPTION
# Pull Request: Add TracerBlockFetcher with Firehose Tracing Poller

## 🔍 Summary
This PR introduces a new `TracerBlockFetcher` implementation to support fetching Ethereum blocks using the `debug_traceFirehoseBlockByNumber` RPC method. It is designed for integration with Firehose pipelines and adds a new CLI poller to use this fetcher.

---

## ✅ What's Included

### 🔧 `TracerBlockFetcher`
- Implements `blockpoller.BlockFetcher` using `debug_traceFirehoseBlockByNumber`.
- Parses response from RPC:
  - Decodes base64-encoded tracing output.
  - Extracts `FIRE BLOCK` line containing protobuf payload.
  - Unmarshals it into a `pbeth.Block` and wraps it in a `bstream.Block`.

### 🧰 CLI Enhancements
- Adds new command: `firehose-tracer-api`
  - Usage: `firehose-tracer-api <rpc-endpoint> <first-streamable-block>`
  - Flags:
    - `--interval-between-fetch`
    - `--max-block-fetch-duration`
- Integrated into `newPollerCmd`.

### 🧠 Poller Internals
- Controlled via `useTracer` flag.
- Reuses `pollerRunEInternal` with a switch for tracer or generic fetcher.
- Hooked into `blockpoller.New(...)` for firehose streaming.

---

## 🧪 Testing

1. Start an archive-node on hoodi
```bash
geth \
  --synctarget=0x3ae141c1953b0c973cafcd3424761d11584b15fb05f68b6caab25d723cfd6bc6 \
  --syncmode=full \
  --hoodi \
  --datadir=data/hoodi-archive-node \
  --db.engine=pebble \
  --state.scheme=path \
  --history.state=0 \
  --gcmode=archive \
  --authrpc.jwtsecret=jwt.txt \
  --authrpc.addr=0.0.0.0 \
  --authrpc.port=10551 \
  --authrpc.vhosts="*" \
  --http \
  --http.addr=0.0.0.0 \
  --http.api=eth,net,web3,debug \
  --http.port=10545 \
  --http.vhosts="*" \
  --port=40304 \
  --ws.port=10546 \
  --ipcpath=/tmp/geth.ipc \
  > /dev/null
```

2. Connect the poller to the port
```bash
fireeth -c "" start reader-node,relayer,merger \
  --reader-node-path=fireeth \
  --reader-node-arguments="tools poller firehose-tracer-api http://localhost:10545 1 --interval-between-fetch=100ms --max-block-fetch-duration=3s" \
  --reader-node-grpc-listen-addr=:11010 \
  --reader-node-manager-api-addr=:11011 \
  --merger-grpc-listen-addr=:10013 \
  --common-first-streamable-block=1 \
  --common-one-block-store-url=./firehose-data/storage/one-blocks \
  --common-merged-blocks-store-url=./firehose-data/storage/merged-blocks \
  --common-forked-blocks-store-url=./firehose-data/storage/forked-blocks
```

3. Result logs
```bash
2025-08-07T20:36:49.080Z INFO (fireeth) about to fetch block {"block_to_fetch": 182, "delay": "0s"}
2025-08-07T20:36:49.080Z INFO (fireeth) requesting block {"block_num": 182}
2025-08-07T20:36:49.501Z INFO (fireeth) block was optimistically polled {"block_num": 182}
2025-08-07T20:36:49.501Z INFO (fireeth) processing block {"block": "#182 (19fa14d512ee6ad35586f1b05c6bd9c1ba3510fbeb1cccefa851436c19fa3ea1)", "lib_num": 0}
2025-08-07T20:36:49.511Z INFO (fireeth) saved cursor {"filepath": "firehose-data/poller-state/cursor.json", "last_fired_block": "182 (19fa14d512ee6ad35586f1b05c6bd9c1ba3510fbeb1cccefa851436c19fa3ea1)", "lib": "1 (c62962979a16131910a073095eadc7e458679bb9336299cd38a6e715c1c47996)", "block_count": 182}
2025-08-07T20:36:49.511Z INFO (fireeth) about to fetch block {"block_to_fetch": 183, "delay": "0s"}
2025-08-07T20:36:49.511Z INFO (fireeth) requesting block {"block_num": 183}
2025-08-07T20:36:50.046Z INFO (fireeth) block was optimistically polled {"block_num": 183}
2025-08-07T20:36:50.046Z INFO (fireeth) processing block {"block": "#183 (38f55ad790f4ebe59d74d845e2e04910db48a7c3102ee6a75fa6dbf8cb3ac80c)", "lib_num": 0}
2025-08-07T20:36:50.058Z INFO (fireeth) saved cursor {"filepath": "firehose-data/poller-state/cursor.json", "last_fired_block": "183 (38f55ad790f4ebe59d74d845e2e04910db48a7c3102ee6a75fa6dbf8cb3ac80c)", "lib": "1 (c62962979a16131910a073095eadc7e458679bb9336299cd38a6e715c1c47996)", "block_count": 183}
2025-08-07T20:36:50.058Z INFO (fireeth) about to fetch block {"block_to_fetch": 184, "delay": "0s"}
2025-08-07T20:36:50.058Z INFO (fireeth) requesting block {"block_num": 184}
2025-08-07T20:36:50.607Z INFO (fireeth) block was optimistically polled {"block_num": 184}
2025-08-07T20:36:50.607Z INFO (fireeth) processing block {"block": "#184 (d3121b77d65d976fc3c33fb25bb78e24c7aed61b18465220d6a38f96fc477192)", "lib_num": 0}
```

---