### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/cmd/fireeth/tools_fix_withdrawals.go
+++ b/cmd/fireeth/tools_fix_withdrawals.go
@@ -65,10 +65,7 @@ func createFixWithdrawalsE(logger *zap.Logger) firecore.CommandExecutor {
 		maxConcurrency := sflags.MustGetInt(cmd, "max-concurrency")
 
 		if maxConcurrency == 0 {
-			maxConcurrency = runtime.GOMAXPROCS(0)
-			if maxConcurrency < 1 {
-				maxConcurrency = 1
-			}
+			maxConcurrency = max(runtime.GOMAXPROCS(0), 1)
 		}
 
 		if stop <= start {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.