### PR TITLE
Align Go toolchain and fix apt flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS build
+FROM golang:1.24.2-bookworm AS build
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . ./
 
 ARG VERSION="dev"
-RUN apt-get update && apt-get install git
+RUN apt-get update && apt-get install -y git
 RUN go build -v -ldflags "-X main.version=${VERSION}" ./cmd/fireeth
 
 FROM ubuntu:24.04

--- a/Dockerfile.nitro
+++ b/Dockerfile.nitro
@@ -8,7 +8,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-       apt-get -y install -y git
+       apt-get -y install git
 
 ARG VERSION=dev
 RUN go build -v -ldflags "-X main.version=${VERSION}" ./cmd/fireeth

--- a/Dockerfile.poller
+++ b/Dockerfile.poller
@@ -1,6 +1,6 @@
 ARG CORE_VERSION=b2cf970
 
-FROM golang:1.23.4-alpine as build
+FROM golang:1.24.2-alpine as build
 WORKDIR /app
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Description

This aligns all Docker build stages to Go 1.24.2 and makes apt installs non-interactive.

## Why this matters
- go.mod declares go 1.24.2; Docker builders were on 1.23.4 (poller) and 1.24.0 (main). Mismatched toolchains can change stdlib behavior and break module resolution. Aligning to 1.24.2 removes that risk and makes builds reproducible.
- `apt-get install` without `-y` can hang CI; `-y` ensures non-interactive runs. Also removes a duplicated `-y` in the nitro Dockerfile.
