### PR TITLE
Fix typos

### DIFF
--- a/cmd/fireeth/tools_compare_blocks_rpc.go
+++ b/cmd/fireeth/tools_compare_blocks_rpc.go
@@ -441,7 +441,7 @@ func decodeAnyPB(in *anypb.Any) (*pbbstream.Block, error) {
 	}
 
 	// We are downloading only final blocks from the Firehose connection which means the LIB for them
-	// can be set to themself (althought we use `- 1` to ensure problem would occur if codde don't like
+	// can be set to themself (although we use `- 1` to ensure problem would occur if code don't like
 	// `LIBNum == self.BlockNum`).
 	return blockEncoder.Encode(firecore.BlockEnveloppe{Block: block, LIBNum: block.Number - 1})
 }

--- a/cmd/fireeth/tools_poll_rpc_blocks.go
+++ b/cmd/fireeth/tools_poll_rpc_blocks.go
@@ -98,7 +98,7 @@ func createPollRPCBlocksE(logger *zap.Logger) firecore.CommandExecutor {
 			b64Cnt := base64.StdEncoding.EncodeToString(cnt)
 			lineCnt := fmt.Sprintf("FIRE BLOCK %d %s %d %s %s", blockNum, hex.EncodeToString(ethBlock.Hash), libNum, hex.EncodeToString(ethBlock.Header.ParentHash), b64Cnt)
 			if _, err := fmt.Println(lineCnt); err != nil {
-				return fmt.Errorf("failed to write log line (char lenght %d): %w", len(lineCnt), err)
+				return fmt.Errorf("failed to write log line (char length %d): %w", len(lineCnt), err)
 			}
 			blockNum++
 		}

--- a/codec/console_reader.go
+++ b/codec/console_reader.go
@@ -246,7 +246,7 @@ func (c *ConsoleReader) next(readType int) (out interface{}, err error) {
 		// We are trying to order the lines based on the amount of time they occur in average
 		// in a sample of lines.
 		//
-		// Easiest way is to use the battelfield dmlog test file we have in the project:
+		// Easiest way is to use the battlefield dmlog test file we have in the project:
 		//
 		//     cat codec/testdata/firehose-logs.dmlog | grep -Eo "(DMLOG|FIRE) ([^ ]+)" | sort | uniq -c | sort -nr
 		//

--- a/codec/postprocess.go
+++ b/codec/postprocess.go
@@ -41,7 +41,7 @@ func normalizeInPlace(block *pbeth.Block, features *normalizationFeatures, first
 	}
 
 	// We reconstruct the state reverted value per call, for each transaction traces. We also
-	// normalize signature curve points since we were not setting to be alwasy 32 bytes long and
+	// normalize signature curve points since we were not setting to be always 32 bytes long and
 	// sometimes, it would have been only 31 bytes long.
 	for _, trx := range block.TransactionTraces {
 		populateTrxStatus(trx)


### PR DESCRIPTION
Fixed some spelling issues including one user-facing message:

- `char lenght %d` → `char length %d` in `cmd/fireeth/tools_poll_rpc_blocks.go` (this one shows up in CLI/logs)
- Various comment typos in `codec/postprocess.go`, `codec/console_reader.go`, and `cmd/fireeth/tools_compare_blocks_rpc.go` (`alwasy` → `always`, `battelfield ` →`battlefield`, `althought ` →`although`, `codde` →`code ` )