### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/cmd/fireeth/compare_lastpartial_to_fullblock_in_stream.go
+++ b/cmd/fireeth/compare_lastpartial_to_fullblock_in_stream.go
@@ -17,7 +17,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -129,7 +129,7 @@ func createRelayerStreamE(chain *firecore.Chain[*pbeth.Block], logger *zap.Logge
 					// Format seen indices
 					seenIdxStr := ""
 					if indices, ok := seenIndices[blk.Number]; ok && len(indices) > 0 {
-						sort.Slice(indices, func(i, j int) bool { return indices[i] < indices[j] })
+						slices.Sort(indices)
 						idxStrings := make([]string, len(indices))
 						for i, idx := range indices {
 							idxStrings[i] = fmt.Sprintf("%d", idx)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.