### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/cmd/fireeth/tools_geth_enforce_peers.go
+++ b/cmd/fireeth/tools_geth_enforce_peers.go
@@ -473,17 +473,17 @@ func (s *GethMonitor) runOnce() error {
 // cannot use ReadAll on an IPC socket
 func readString(r io.Reader) (string, error) {
 	br := bufio.NewReader(r)
-	var line string
+	var line strings.Builder
 	for {
 		l, err := br.ReadString('\n')
 		if len(l) > 0 {
-			line += l
+			line.WriteString(l)
 		}
 		switch err {
 		case bufio.ErrBufferFull:
 			continue
 		case io.EOF, nil:
-			return line, nil
+			return line.String(), nil
 		default:
 			return "", err
 		}


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)