### PR TITLE
Copilot/fix fireeth crash issue

### DIFF
--- a/blockfetcher/rpc.go
+++ b/blockfetcher/rpc.go
@@ -82,7 +82,7 @@ func (f *BlockFetcher) FetchPBEth(ctx context.Context, rpcClient *rpc.Client, bl
 	}
 
 	if rpcBlock == nil {
-		return nil, fmt.Errorf("block %d not found: rpc returned nil block", blockNum)
+		return nil, fmt.Errorf("block %d not found or unavailable", blockNum)
 	}
 
 	if rpcBlock.Hash == nil {

--- a/blockfetcher/rpc.go
+++ b/blockfetcher/rpc.go
@@ -81,6 +81,14 @@ func (f *BlockFetcher) FetchPBEth(ctx context.Context, rpcClient *rpc.Client, bl
 		return nil, fmt.Errorf("fetching block %d: %w", blockNum, err)
 	}
 
+	if rpcBlock == nil {
+		return nil, fmt.Errorf("block %d not found: rpc returned nil block", blockNum)
+	}
+
+	if rpcBlock.Hash == nil {
+		return nil, fmt.Errorf("block %d has nil hash", blockNum)
+	}
+
 	blockHash := eth.Bytes(rpcBlock.Hash.Bytes())
 	var receipts map[string]*rpc.TransactionReceipt
 	var logs map[string][]eth.Log


### PR DESCRIPTION
fireeth has error in rpc poller
`panic: runtime error: invalid memory address or nil pointer dereference`
This issue should be caught.


```
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: 2026-02-13T13:31:52.221Z INFO (fireeth) about to fetch block {"block_to_fetch": 14453658, "delay": "0s", "keep": false}
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: 2026-02-13T13:31:52.221Z INFO (fireeth) requesting block {"block_num": 14453658, "keep": false}
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: 2026-02-13T13:31:52.221Z INFO (fireeth) optimistically fetching block {"block_num": 14453658}
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: panic: runtime error: invalid memory address or nil pointer dereference
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x29a0536]
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: goroutine 170 [running]:
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-ethereum/blockfetcher.(*BlockFetcher).FetchPBEth(0xc0009a2e10, {0x48779a8, 0xc000494e70}, 0xc00087c2d0, 0xdc8b9a)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /tmp/build.1770399580.1131057/firehose-ethereum/blockfetcher/rpc.go:84 +0x456
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-ethereum/blockfetcher.(*BlockFetcher).Fetch(0x12d3ac22d?, {0x48779a8?, 0xc000494e70?}, 0xc000494e70?, 0x0?)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /tmp/build.1770399580.1131057/firehose-ethereum/blockfetcher/rpc.go:109 +0x32
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-ethereum/blockfetcher.(*OptimismBlockFetcher).Fetch(0x688e720?, {0x48779a8?, 0xc000494e70?}, 0xc000e18ab8?, 0xc000e18b18?)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /tmp/build.1770399580.1131057/firehose-ethereum/blockfetcher/optimism.go:23 +0x25
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-core/blockpoller.(*BlockPoller[...]).loadNextBlocks.func1.1.1(0x12a05f200?)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/firehose-core@v1.12.8-0.20260204205908-b72327541de4/blockpoller/poller.go:232 +0x47
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-core/rpc.WithClientsContext[...](0xc000b18a40?, {0x48776a0, 0x68b4f00}, 0xc000d13c28)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/firehose-core@v1.12.8-0.20260204205908-b72327541de4/rpc/clients.go:74 +0x1bc
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-core/rpc.WithClients[...](...)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/firehose-core@v1.12.8-0.20260204205908-b72327541de4/rpc/clients.go:92
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-core/blockpoller.(*BlockPoller[...]).loadNextBlocks.func1.1()
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/firehose-core@v1.12.8-0.20260204205908-b72327541de4/blockpoller/poller.go:231 +0x75
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/derr.RetryContext.func1({0x48776a0?, 0x68b4f00?})
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/derr@v0.0.0-20250814163534-bd7407bd89d7/retry.go:69 +0x25
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/sethvargo/go-retry.Do({0x48776a0, 0x68b4f00}, {0x4834780, 0xc000886900}, 0xc000d13d80)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/sethvargo/go-retry@v0.2.3/retry.go:60 +0x8a
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/derr.RetryContext({0x48776a0, 0x68b4f00}, 0x7ff966101e20?, 0xc000901630)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/derr@v0.0.0-20250814163534-bd7407bd89d7/retry.go:68 +0x55
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/derr.Retry(0x100f9af5bf210?, 0x7ff9af42eb68?)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/derr@v0.0.0-20250814163534-bd7407bd89d7/retry.go:62 +0x27
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/firehose-core/blockpoller.(*BlockPoller[...]).loadNextBlocks.func1(0xdc8b9a?)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/firehose-core@v1.12.8-0.20260204205908-b72327541de4/blockpoller/poller.go:229 +0x69
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: github.com/streamingfast/dhammer.(*Nailer[...]).processInput(0xdc8b9a, 0xdc8b9a?, 0xc000494e00)
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/dhammer@v0.0.0-20230125192823-c34bbd561bd4/nailer.go:267 +0xb4
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]: created by github.com/streamingfast/dhammer.(*Nailer[...]).runInput in goroutine 167
Feb 13 13:31:52 moonbeam-sfdm813 sf[19612]:         /var/lib/golang/pkg/github.com/streamingfast/dhammer@v0.0.0-20230125192823-c34bbd561bd4/nailer.go:255 +0x69
```