### PR TITLE
poller: add --block-fetch-batch-size for parallel block fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ for instructions to keep up to date.
 - Substreams: fix `Sinker.requestActiveStartBlock` not being set when the handler implements `SinkerSessionInitHandler`, which previously caused `ProgressMessageLastContiguousBlock` to be incorrect for production-mode mapper stages.
 - Substreams: detect reorgs in executed partial blocks even when the transaction hashes are identical. Previously a recomputed block whose only difference was its state (same, equally-ordered transactions) was not detected as replaced, so no reorg was triggered; more block fields are now validated to catch this.
 
+### Added
+
+- `tools poller`: new `--block-fetch-batch-size` flag (default 1) that fetches multiple blocks in parallel ahead of the cursor, while still firing them to stdout strictly in order. Speeds up ingestion on chains with large blocks.
+
 ## v2.17.4
 
 ### Changed

--- a/cmd/fireeth/poller.go
+++ b/cmd/fireeth/poller.go
@@ -26,6 +26,7 @@ func newPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().Uint("parallel-workers", 20, "number of parallel workers to fetch transaction receipts")
+	cmd.PersistentFlags().Uint("block-fetch-batch-size", 1, "number of blocks to fetch (and serialize) in parallel")
 	cmd.PersistentFlags().StringSliceP("headers", "H", nil, "headers to send with each request (ex: '-H \"key1: value1\" -H \"key2: value2\"')")
 	cmd.PersistentFlags().Bool("allow-empty-receipts-on-block-0", false, "whether to accept empty receipts on block 0, filling them with 'empty' transactions (useful for TRON-EVM)")
 
@@ -86,7 +87,7 @@ func newFirehoseTracerPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobr
 			and block-level analysis.
 
 			*Experimental*: This tool is not production-ready. Intended for development
-			and debugging purposes only. 
+			and debugging purposes only.
 		`),
 		Args: cobra.ExactArgs(2),
 		RunE: pollerRunEForTracer(logger),
@@ -111,6 +112,7 @@ func pollerRunEInternal(logger *zap.Logger, tracer logging.Tracer, useTracer boo
 		//dataDir := cmd.Flag("data-dir").Value.String()
 		fetchInterval := sflags.MustGetDuration(cmd, "interval-between-fetch")
 		parallelWorkers := sflags.MustGetInt(cmd, "parallel-workers")
+		blockFetchBatchSize := sflags.MustGetInt(cmd, "block-fetch-batch-size")
 		maxBlockFetchDuration := sflags.MustGetDuration(cmd, "max-block-fetch-duration")
 
 		dataDir := sflags.MustGetString(cmd, "data-dir")
@@ -128,6 +130,7 @@ func pollerRunEInternal(logger *zap.Logger, tracer logging.Tracer, useTracer boo
 			zap.Duration("fetch_interval", fetchInterval),
 			zap.Duration("max_block_fetch_duration", maxBlockFetchDuration),
 			zap.Uint64("first_streamable_block", firstStreamableBlock),
+			zap.Int("block_fetch_batch_size", blockFetchBatchSize),
 		)
 		rpcClients := firecorerpc.NewClients[*rpc.Client](maxBlockFetchDuration, firecorerpc.NewStickyRollingStrategy[*rpc.Client](), logger)
 
@@ -152,7 +155,7 @@ func pollerRunEInternal(logger *zap.Logger, tracer logging.Tracer, useTracer boo
 		handler := blockpoller.NewFireBlockHandler("type.googleapis.com/sf.ethereum.type.v2.Block")
 		poller := blockpoller.New[*rpc.Client](fetcher, handler, rpcClients, blockpoller.WithStoringState[*rpc.Client](stateDir), blockpoller.WithLogger[*rpc.Client](logger))
 
-		err = poller.Run(firstStreamableBlock, nil, 1)
+		err = poller.Run(firstStreamableBlock, nil, blockFetchBatchSize)
 		if err != nil {
 			return fmt.Errorf("running poller: %w", err)
 		}


### PR DESCRIPTION
Currently the poller fetches and serializes blocks strictly one at a time (Run(..., 1) hardcoded), so on chains with large blocks ingestion could be quite slow. The blockpoller already supports parallel prefetch via dhammer.Nailer; expose it as a flag.

- Add `--block-fetch-batch-size` (default 1, preserving current behavior).
- Pass it to `poller.Run` so N blocks are fetched and serialized in parallel ahead of the cursor. Firing to stdout stays strictly sequential and in order (Nailer linearizes output; the poll loop fires one block at a time), so the reader-node still sees ordered blocks.

Tested on MegaEth:
```
  batch=1   ->   23 blocks in 45s  (0.5 blk/s)                                                                                                           
  batch=2   ->   44 blocks in 45s  (1.0 blk/s)                                                                                                           
  batch=4   ->   76 blocks in 45s  (1.7 blk/s)                                                                                                           
  batch=8   ->  128 blocks in 45s  (2.8 blk/s)                                                                                                           
  batch=16  ->  207 blocks in 45s  (4.6 blk/s)                                                                                                           
  batch=32  ->  256 blocks in 45s  (5.7 blk/s)                                                                                                           
  batch=64  ->  320 blocks in 45s  (7.1 blk/s)                                                                                                           \
```  

Requires https://github.com/streamingfast/firehose-core/pull/152/ to work, will bump the the dependency once it's merged.