### PR TITLE
Bump firehose-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ for instructions to keep up to date.
 ### Changed
 
 - Bumped `dstore`: S3 store now suppresses the SDK's checksum validation warnings (sets `DisableLogOutputChecksumValidationSkipped` to `true`) and updates the AWS S3 SDK to a newer version.
+- Substreams: the tier1 job scheduler no longer slows down on very large reprocessings (100_000s of segments). `NextJob` and `AllStoresCompleted` used to rescan the whole completed-segment prefix on every scheduling event (O(segments²) over a run) and now advance a forward-only cursor (O(1) amortized). Progress reporting (`UpdateStats`) builds each stage's ranges in a single sort-free pass, the scheduler event loop drops per-message overhead (debug-state env var read once at startup, debug log fields built only when debug logging is enabled), and the cached-output streaming buffer appends and checks for flushing under a single lock per block.
+- Substreams: `SUBSTREAMS_STORE_SIZE_LIMIT` is now passed from tier1 to tier2; when set on tier1 it overrides the tier2 env var value.
+
+### Added
+
+- Reader: two prometheus gauges to watch how close blocks read out of the node are to the `reader-node-line-buffer-size` hard limit: `reader_node_max_read_block_size_bytes` (high-water mark of the largest line/block read) and `reader_node_line_buffer_size_bytes` (the configured limit).
+
+### Fixed
+
+- Substreams: fix `Sinker.requestActiveStartBlock` not being set when the handler implements `SinkerSessionInitHandler`, which previously caused `ProgressMessageLastContiguousBlock` to be incorrect for production-mode mapper stages.
+- Substreams: detect reorgs in executed partial blocks even when the transaction hashes are identical. Previously a recomputed block whose only difference was its state (same, equally-ordered transactions) was not detected as replaced, so no reorg was triggered; more block fields are now validated to catch this.
 
 ## v2.17.4
 

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,12 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260520032149-6421410d7faa
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.14.5-0.20260601154750-a7db8ec6b293
+	github.com/streamingfast/firehose-core v1.14.6-0.20260609191559-fdcb22644a1d
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.18.6-0.20260601154655-19d4ddc787d2
+	github.com/streamingfast/substreams v1.18.6-0.20260609175527-582cdef95f07
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -2335,8 +2335,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.14.5-0.20260601154750-a7db8ec6b293 h1:bC9WWiMZSCbOCDHF63i06amuHTcVaZeKZG4hGb4oxjw=
-github.com/streamingfast/firehose-core v1.14.5-0.20260601154750-a7db8ec6b293/go.mod h1:d7yrhoW1fyzfxu6bDqvUl4nzrAzVjAo1hWJJtEA3N7s=
+github.com/streamingfast/firehose-core v1.14.6-0.20260609191559-fdcb22644a1d h1:QRb1wxS/nv9guo3F/RD6J1Q3+8YM/LlWwiRUw2HJ4Hs=
+github.com/streamingfast/firehose-core v1.14.6-0.20260609191559-fdcb22644a1d/go.mod h1:Ql/OLt+1oqNAO8m1injUKUpCJec8uqrOu91A+Bp+mzo=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=
@@ -2364,8 +2364,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.18.6-0.20260601154655-19d4ddc787d2 h1:VM4TZwnhg/0swab+aS8IMrYVkaAw2KzZzjivcIyN0Uw=
-github.com/streamingfast/substreams v1.18.6-0.20260601154655-19d4ddc787d2/go.mod h1:J4QbQ90xcegaBuzWIPfDSwDlaEHnadin5u6FX1NjjgU=
+github.com/streamingfast/substreams v1.18.6-0.20260609175527-582cdef95f07 h1:Gd4owCCyuMGNv2c/9xX4+anUA8o+iLezcwsrcT4AQrM=
+github.com/streamingfast/substreams v1.18.6-0.20260609175527-582cdef95f07/go.mod h1:J4QbQ90xcegaBuzWIPfDSwDlaEHnadin5u6FX1NjjgU=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `firehose-core` to `v1.14.6-0.20260609191559-fdcb22644a1d` (which also pulls substreams `v1.18.6-0.20260609175527-582cdef95f07`).

Changelog mirrored from firehose-core:

- Substreams: tier1 job scheduler performance on very large reprocessings (forward-only cursor, sort-free progress reporting, lower per-message overhead).
- Substreams: `SUBSTREAMS_STORE_SIZE_LIMIT` now passed from tier1 to tier2.
- Substreams: fix sink `requestActiveStartBlock` for `SinkerSessionInitHandler`.
- Substreams: detect reorgs in executed partial blocks even when transaction hashes are identical.
- Reader: new `reader_node_max_read_block_size_bytes` and `reader_node_line_buffer_size_bytes` prometheus gauges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)