### PR TITLE
add source_head_block_time_drift per-source metric on relayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ for instructions to keep up to date.
 
 ### Added
 
+- Relayer: new per-source prometheus gauge `source_head_block_time_drift{app="relayer",source=...}` reporting the number of seconds since the last block received from each source. The drift is computed at scrape time, so it keeps growing while a source is silent.
 - Reader: two prometheus gauges to watch how close blocks read out of the node are to the `reader-node-line-buffer-size` hard limit: `reader_node_max_read_block_size_bytes` (high-water mark of the largest line/block read) and `reader_node_line_buffer_size_bytes` (the configured limit).
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260520032149-6421410d7faa
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.14.6-0.20260609191559-fdcb22644a1d
+	github.com/streamingfast/firehose-core v1.14.6-0.20260612171821-f60c4c1304fb
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437

--- a/go.sum
+++ b/go.sum
@@ -2335,8 +2335,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.14.6-0.20260609191559-fdcb22644a1d h1:QRb1wxS/nv9guo3F/RD6J1Q3+8YM/LlWwiRUw2HJ4Hs=
-github.com/streamingfast/firehose-core v1.14.6-0.20260609191559-fdcb22644a1d/go.mod h1:Ql/OLt+1oqNAO8m1injUKUpCJec8uqrOu91A+Bp+mzo=
+github.com/streamingfast/firehose-core v1.14.6-0.20260612171821-f60c4c1304fb h1:66a6Tzby3o1tO0g4txT9WaNjeubQpEicEAx6ug6VVg0=
+github.com/streamingfast/firehose-core v1.14.6-0.20260612171821-f60c4c1304fb/go.mod h1:SSO/125/K+DDuTKoe2Do7QSMWOqjCXrknsp1Z61CJ1Q=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=


### PR DESCRIPTION
bumped to firehose-core@develop