### PR TITLE
Fix eth_getBalance block param encoding and -32602 retry loop

### DIFF
--- a/substreams/rpccalls.go
+++ b/substreams/rpccalls.go
@@ -367,12 +367,19 @@ func (e *RPCEngine) rpcDoWithRetry(
 				}
 			}
 			if retryWithLatest {
-				// Rebuild reqs with latest block
+				// Rebuild reqs with latest block, but only if we are not already
+				// querying "latest": otherwise a persistent -32602 would retry forever.
+				fallbackApplied := false
 				for _, req := range reqs {
-					req.Params[1] = "latest"
+					if req.Params[1] != "latest" {
+						req.Params[1] = "latest"
+						fallbackApplied = true
+					}
 				}
-				zlog.Warn("retrying eth_getBalance with latest block due to missing block (-32602)", zap.String("trace_id", traceID), zap.String("original_block", blockHash))
-				continue
+				if fallbackApplied {
+					zlog.Warn("retrying eth_getBalance with latest block due to missing block (-32602)", zap.String("trace_id", traceID), zap.String("original_block", blockHash))
+					continue
+				}
 			}
 		}
 

--- a/substreams/rpccalls.go
+++ b/substreams/rpccalls.go
@@ -255,7 +255,7 @@ func (e *RPCEngine) ethGetBalance(
 		if fallbackDuration != 0 && blockAge > fallbackDuration {
 			blockParam = "latest"
 		} else if numberDuration != 0 && blockAge > numberDuration {
-			blockParam = strconv.FormatUint(clock.Number, 10)
+			blockParam = fmt.Sprintf("0x%x", clock.Number)
 		}
 
 		rpcReqs[i] = &rpc.RPCRequest{

--- a/substreams/rpccalls.go
+++ b/substreams/rpccalls.go
@@ -248,8 +248,13 @@ func (e *RPCEngine) ethGetBalance(
 		addrHex := "0x" + hex.EncodeToString(r.Address)
 
 		blockParam := r.Block
-		if blockParam != "" && !strings.HasPrefix(blockParam, "0x") {
-			blockParam = "0x" + blockParam
+		switch blockParam {
+		case "latest", "pending", "earliest", "safe", "finalized":
+			// known block tags are passed through unchanged
+		default:
+			if blockParam != "" && !strings.HasPrefix(blockParam, "0x") {
+				blockParam = "0x" + blockParam
+			}
 		}
 
 		if fallbackDuration != 0 && blockAge > fallbackDuration {

--- a/substreams/rpccalls_test.go
+++ b/substreams/rpccalls_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -488,7 +489,8 @@ func TestRPCEngine_ethGetBalance_retryWithFallback(t *testing.T) {
 
 		count++
 		if count == 1 {
-			// Return -32602 error
+			// First call uses the block hash, return -32602 error
+			assert.Contains(t, buffer.String(), clockBlock1.Id)
 			w.Write([]byte(`{"jsonrpc":"2.0","id":"0x1","error":{"code":-32602,"message":"Invalid params"}}`))
 		} else {
 			// Second call should use "latest"
@@ -513,9 +515,13 @@ func TestRPCEngine_ethGetBalance_retryWithFallback(t *testing.T) {
 	in, err := proto.Marshal(reqProto)
 	require.NoError(t, err)
 
-	out, det, err := engine.ethGetBalance(ctx, 1, "traceID", clockBlock1, in)
+	// Recent block: initial request uses the block hash, the -32602 answer
+	// triggers a single fallback retry with "latest"
+	clock := &pbsubstreams.Clock{Number: 1, Id: clockBlock1.Id, Timestamp: timestamppb.Now()}
+	out, det, err := engine.ethGetBalance(ctx, 1, "traceID", clock, in)
 	require.NoError(t, err)
 	require.True(t, det)
+	require.Equal(t, 2, count)
 
 	got := &pbethss.RpcGetBalanceResponses{}
 	require.NoError(t, proto.Unmarshal(out, got))
@@ -526,6 +532,73 @@ func TestRPCEngine_ethGetBalance_retryWithFallback(t *testing.T) {
 				{Balance: eth.MustNewBytes("0x01"), Failed: false},
 			},
 		},
+		got,
+	)
+}
+
+func TestRPCEngine_ethGetBalance_persistent32602_noInfiniteLoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = reqctx.WithEthCallFallbackToLatestDuration(ctx, 1*time.Hour)
+
+	var mu sync.Mutex
+	count := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		// Endpoint persistently answers -32602, even for "latest"
+		w.Write([]byte(`{"jsonrpc":"2.0","id":"0x1","error":{"code":-32602,"message":"Invalid params"}}`))
+	}))
+	defer server.Close()
+
+	engine, err := NewRPCEngine([]string{server.URL}, []string{server.URL}, 50_000_000)
+	require.NoError(t, err)
+
+	reqProto := &pbethss.RpcGetBalanceRequests{
+		Requests: []*pbethss.RpcGetBalanceRequest{{
+			Address: eth.MustNewAddress("0xea674fdde714fd979de3edf0f56aa9716b898ec8"),
+			Block:   clockBlock1.Id,
+		}},
+	}
+	in, err := proto.Marshal(reqProto)
+	require.NoError(t, err)
+
+	// Recent block so the initial request uses the block hash, then falls back to "latest"
+	clock := &pbsubstreams.Clock{Number: 1, Id: clockBlock1.Id, Timestamp: timestamppb.Now()}
+
+	var out []byte
+	var det bool
+	var callErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		out, det, callErr = engine.ethGetBalance(ctx, 1, "traceID", clock, in)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("ethGetBalance never returned: infinite -32602 fallback retry loop")
+	}
+
+	require.NoError(t, callErr)
+	require.True(t, det)
+
+	// One attempt with the block hash, one with "latest", then stop
+	mu.Lock()
+	require.Equal(t, 2, count)
+	mu.Unlock()
+
+	got := &pbethss.RpcGetBalanceResponses{}
+	require.NoError(t, proto.Unmarshal(out, got))
+
+	assertProtoEqual(t,
+		&pbethss.RpcGetBalanceResponses{Responses: []*pbethss.RpcGetBalanceResponse{
+			{Failed: true},
+		}},
 		got,
 	)
 }

--- a/substreams/rpccalls_test.go
+++ b/substreams/rpccalls_test.go
@@ -536,6 +536,52 @@ func TestRPCEngine_ethGetBalance_retryWithFallback(t *testing.T) {
 	)
 }
 
+func TestRPCEngine_ethGetBalance_blockTagPassthrough(t *testing.T) {
+	for _, tag := range []string{"latest", "pending", "earliest", "safe", "finalized"} {
+		t.Run(tag, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				buffer := bytes.NewBuffer(nil)
+				_, err := buffer.ReadFrom(r.Body)
+				require.NoError(t, err)
+
+				// Block tags must be passed through unchanged, not mangled into "0x<tag>"
+				assert.Equal(t,
+					`[{"params":["0xea674fdde714fd979de3edf0f56aa9716b898ec8","`+tag+`"],"method":"eth_getBalance","jsonrpc":"2.0","id":"0x1"}]`,
+					buffer.String(),
+				)
+				w.Write([]byte(`{"jsonrpc":"2.0","id":"0x1","result":"0x01"}`))
+			}))
+			defer server.Close()
+
+			engine, err := NewRPCEngine([]string{server.URL}, []string{server.URL}, 50_000_000)
+			require.NoError(t, err)
+
+			reqProto := &pbethss.RpcGetBalanceRequests{
+				Requests: []*pbethss.RpcGetBalanceRequest{{
+					Address: eth.MustNewAddress("0xea674fdde714fd979de3edf0f56aa9716b898ec8"),
+					Block:   tag,
+				}},
+			}
+			in, err := proto.Marshal(reqProto)
+			require.NoError(t, err)
+
+			out, det, err := engine.ethGetBalance(context.Background(), 1, "traceID", clockBlock1, in)
+			require.NoError(t, err)
+			require.True(t, det)
+
+			got := &pbethss.RpcGetBalanceResponses{}
+			require.NoError(t, proto.Unmarshal(out, got))
+
+			assertProtoEqual(t,
+				&pbethss.RpcGetBalanceResponses{Responses: []*pbethss.RpcGetBalanceResponse{
+					{Balance: eth.MustNewBytes("0x01"), Failed: false},
+				}},
+				got,
+			)
+		})
+	}
+}
+
 func TestRPCEngine_ethGetBalance_persistent32602_noInfiniteLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/substreams/rpccalls_test.go
+++ b/substreams/rpccalls_test.go
@@ -530,6 +530,57 @@ func TestRPCEngine_ethGetBalance_retryWithFallback(t *testing.T) {
 	)
 }
 
+func TestRPCEngine_ethGetBalance_useBlockNumber_hexEncoding(t *testing.T) {
+	ctx := reqctx.WithEthCallUseBlockNumberDuration(context.Background(), 1*time.Hour)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buffer := bytes.NewBuffer(nil)
+		_, err := buffer.ReadFrom(r.Body)
+		require.NoError(t, err)
+
+		// Block number must be hex encoded ("0x..."), like the eth_call path, not decimal
+		assert.Equal(t,
+			`[{"params":["0xea674fdde714fd979de3edf0f56aa9716b898ec8","0xbc614e"],"method":"eth_getBalance","jsonrpc":"2.0","id":"0x1"}]`,
+			buffer.String(),
+		)
+		w.Write([]byte(`{"jsonrpc":"2.0","id":"0x1","result":"0x01"}`))
+	}))
+	defer server.Close()
+
+	engine, err := NewRPCEngine([]string{server.URL}, []string{server.URL}, 50_000_000)
+	require.NoError(t, err)
+
+	reqProto := &pbethss.RpcGetBalanceRequests{
+		Requests: []*pbethss.RpcGetBalanceRequest{{
+			Address: eth.MustNewAddress("0xea674fdde714fd979de3edf0f56aa9716b898ec8"),
+			Block:   "0x10155bcb0fab82ccdc5edc8577f0f608ae059f93720172d11ca0fc01438b08a5",
+		}},
+	}
+	in, err := proto.Marshal(reqProto)
+	require.NoError(t, err)
+
+	// Block is 2 hours old, older than the 1 hour block-number duration
+	clock := &pbsubstreams.Clock{
+		Number:    12345678,
+		Id:        "0x10155bcb0fab82ccdc5edc8577f0f608ae059f93720172d11ca0fc01438b08a5",
+		Timestamp: timestamppb.New(time.Now().Add(-2 * time.Hour)),
+	}
+
+	out, det, err := engine.ethGetBalance(ctx, 1, "traceID", clock, in)
+	require.NoError(t, err)
+	require.True(t, det)
+
+	got := &pbethss.RpcGetBalanceResponses{}
+	require.NoError(t, proto.Unmarshal(out, got))
+
+	assertProtoEqual(t,
+		&pbethss.RpcGetBalanceResponses{Responses: []*pbethss.RpcGetBalanceResponse{
+			{Balance: eth.MustNewBytes("0x01"), Failed: false},
+		}},
+		got,
+	)
+}
+
 func TestRPCEngine_rpcCalls_useBlockNumber_olderThanDuration(t *testing.T) {
 	ctx := context.Background()
 	ctx = reqctx.WithEthCallUseBlockNumberDuration(ctx, 1*time.Hour)


### PR DESCRIPTION
## Fixes

Three bugs in the `eth_get_balance` WASM extension (`substreams/rpccalls.go`), all divergences from the behavior of its `eth_call` twin:

1. **Decimal block number** — with `ETH_CALL_USE_BLOCK_NUMBER_DURATION` active, the block param was built as a decimal string (`strconv.FormatUint(clock.Number, 10)`), which Geth rejects with -32602. Now hex-encoded (`0x%x`) like the eth_call path.

2. **Infinite -32602 retry** — the fallback-to-latest retry rewrote params to `"latest"` and continued unconditionally, so an endpoint persistently answering -32602 caused an infinite loop that bypassed `retryCount`. Now guarded like the eth_call path: fall back only once; if params are already `"latest"`, return the deterministic Failed responses.

3. **Mangled block tags** — any non-0x block string was blindly 0x-prefixed, turning `"latest"` into `"0xlatest"` (-32602). Known tags (latest, pending, earliest, safe, finalized) now pass through unchanged.

## Tests

Each fix comes with a repro test against an httptest fake JSON-RPC endpoint that inspects the request bodies; each was verified to fail before its fix:

- `TestRPCEngine_ethGetBalance_useBlockNumber_hexEncoding` — asserts the wire param is `"0xbc614e"`, not `"12345678"`.
- `TestRPCEngine_ethGetBalance_persistent32602_noInfiniteLoop` — endpoint always returns -32602; asserts the call returns (Failed=true, no error) after exactly 2 attempts, guarded by a 20s watchdog (pre-fix: never returns).
- `TestRPCEngine_ethGetBalance_blockTagPassthrough` — all five block tags reach the wire unchanged.

The pre-existing `TestRPCEngine_ethGetBalance_retryWithFallback` was adjusted: it only passed because of bug 2 (its clock had no timestamp, so the first request was already `"latest"` and the retry was latest→latest). It now uses a recent timestamp and exercises the intended hash-then-latest sequence.

`go test ./substreams/...` — 19/19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
