### PR TITLE
Fix fireeth tools: sanitizer bloom check, corrupt-bundle panics, poll-rpc-blocks protocol

### DIFF
--- a/cmd/fireeth/tools_find_unknown_status.go
+++ b/cmd/fireeth/tools_find_unknown_status.go
@@ -83,6 +83,9 @@ func scanForUnknownStatusE(logger *zap.Logger) firecore.CommandExecutor {
 				if err == io.EOF {
 					break
 				}
+				if err != nil {
+					return fmt.Errorf("reading block from %s: %w", filename, err)
+				}
 
 				ethBlock := &pbeth.Block{}
 				err = block.Payload.UnmarshalTo(ethBlock)

--- a/cmd/fireeth/tools_fix_any_type.go
+++ b/cmd/fireeth/tools_fix_any_type.go
@@ -87,6 +87,9 @@ func createFixAnyTypeE(logger *zap.Logger) firecore.CommandExecutor {
 				if err == io.EOF {
 					break
 				}
+				if err != nil {
+					return fmt.Errorf("reading block from %s: %w", filename, err)
+				}
 				if !strings.HasPrefix(block.Payload.TypeUrl, "type.googleapis.com/") {
 					fmt.Println("found block with missing type url prefix", block.Payload.TypeUrl)
 					block.Payload.TypeUrl = "type.googleapis.com/" + block.Payload.TypeUrl

--- a/cmd/fireeth/tools_poll_rpc_blocks.go
+++ b/cmd/fireeth/tools_poll_rpc_blocks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/emmansun/base64" // benchmarked 3x faster than standard encoding/base64
 
 	"github.com/streamingfast/firehose-ethereum/blockfetcher"
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
 
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/eth-go/rpc"
@@ -54,14 +55,14 @@ func createPollRPCBlocksE(logger *zap.Logger) firecore.CommandExecutor {
 		}
 		client := rpc.NewClient(rpcEndpoint)
 
-		fmt.Println("FIRE INIT 2.3 local v1.0.0")
+		fmt.Println("FIRE INIT 3.0 local v1.0.0")
 
 		blockNum := startBlockNum
 		latest := uint64(0)
 		for {
 
 			if latest <= blockNum {
-				latest, err := client.LatestBlockNum(ctx)
+				latest, err = client.LatestBlockNum(ctx)
 				if err != nil {
 					delay(err)
 					continue
@@ -86,21 +87,42 @@ func createPollRPCBlocksE(logger *zap.Logger) firecore.CommandExecutor {
 			}
 
 			ethBlock, _ := block.RpcToEthBlock(rpcBlock, receipts, nil, logger)
-			cnt, err := ethBlock.MarshalVT()
-			if err != nil {
-				return fmt.Errorf("failed to proto  marshal pb sol block: %w", err)
-			}
 
-			libNum := uint64(0)
-			if blockNum != 0 {
-				libNum = blockNum - 1
+			lineCnt, err := fireBlockLine(ethBlock)
+			if err != nil {
+				return fmt.Errorf("generating FIRE BLOCK line for block %d: %w", blockNum, err)
 			}
-			b64Cnt := base64.StdEncoding.EncodeToString(cnt)
-			lineCnt := fmt.Sprintf("FIRE BLOCK %d %s %d %s %s", blockNum, hex.EncodeToString(ethBlock.Hash), libNum, hex.EncodeToString(ethBlock.Header.ParentHash), b64Cnt)
 			if _, err := fmt.Println(lineCnt); err != nil {
 				return fmt.Errorf("failed to write log line (char length %d): %w", len(lineCnt), err)
 			}
 			blockNum++
 		}
 	}
+}
+
+// fireBlockLine formats a Firehose protocol version 3.0 'FIRE BLOCK' line, as expected
+// by codec.(*parseCtx).readBlockForProtocolVersion3:
+//
+//	FIRE BLOCK <num> <hash> <parent_num> <parent_hash> <lib_num> <timestamp_unix_nano> <b64_payload>
+func fireBlockLine(ethBlock *pbeth.Block) (string, error) {
+	payload, err := ethBlock.MarshalVT()
+	if err != nil {
+		return "", fmt.Errorf("failed to proto marshal pb eth block: %w", err)
+	}
+
+	parentNum := uint64(0)
+	if ethBlock.Number != 0 {
+		parentNum = ethBlock.Number - 1
+	}
+	libNum := parentNum
+
+	return fmt.Sprintf("FIRE BLOCK %d %s %d %s %d %d %s",
+		ethBlock.Number,
+		hex.EncodeToString(ethBlock.Hash),
+		parentNum,
+		hex.EncodeToString(ethBlock.Header.ParentHash),
+		libNum,
+		ethBlock.Header.Timestamp.AsTime().UnixNano(),
+		base64.StdEncoding.EncodeToString(payload),
+	), nil
 }

--- a/cmd/fireeth/tools_poll_rpc_blocks_test.go
+++ b/cmd/fireeth/tools_poll_rpc_blocks_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/firehose-ethereum/codec"
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestFireBlockLineParsedByConsoleReader(t *testing.T) {
+	blockTime := time.Unix(1700000000, 123456789).UTC()
+	blockHash := []byte{0xab, 0xcd, 0xef, 0x01}
+	parentHash := []byte{0x12, 0x34, 0x56, 0x78}
+
+	ethBlock := &pbeth.Block{
+		Hash:   blockHash,
+		Number: 42,
+		Ver:    3,
+		Header: &pbeth.BlockHeader{
+			ParentHash: parentHash,
+			Timestamp:  timestamppb.New(blockTime),
+		},
+	}
+
+	line, err := fireBlockLine(ethBlock)
+	require.NoError(t, err)
+
+	lines := make(chan string, 2)
+	lines <- "FIRE INIT 3.0 local v1.0.0"
+	lines <- line
+	close(lines)
+
+	reader, err := codec.NewConsoleReader(lines, nil, zap.NewNop(), nil)
+	require.NoError(t, err)
+
+	block, err := reader.ReadBlock()
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(42), block.Number)
+	require.Equal(t, hex.EncodeToString(blockHash), block.Id)
+	require.Equal(t, uint64(41), block.ParentNum)
+	require.Equal(t, hex.EncodeToString(parentHash), block.ParentId)
+	require.Equal(t, uint64(41), block.LibNum)
+	require.Equal(t, blockTime.UnixNano(), block.Timestamp.AsTime().UnixNano())
+
+	// payload round-trips back to the original eth block
+	parsed := &pbeth.Block{}
+	require.NoError(t, block.Payload.UnmarshalTo(parsed))
+	require.Equal(t, uint64(42), parsed.Number)
+	require.Equal(t, blockHash, parsed.Hash)
+	require.Equal(t, parentHash, parsed.Header.ParentHash)
+}

--- a/cmd/fireeth/tools_read_errors_test.go
+++ b/cmd/fireeth/tools_read_errors_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/streamingfast/bstream"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	"github.com/streamingfast/dstore"
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// writeCorruptBundle writes a merged blocks bundle named 0000000100 containing one
+// valid block followed by a truncated dbin frame (frame length says 1000 bytes but
+// only 3 are present), simulating a corrupt/truncated file.
+func writeCorruptBundle(t *testing.T, ctx context.Context, store dstore.Store) {
+	t.Helper()
+
+	payload, err := anypb.New(&pbeth.Block{
+		Hash:   []byte{0xaa},
+		Number: 100,
+		Header: &pbeth.BlockHeader{
+			ParentHash: []byte{0xbb},
+			Timestamp:  timestamppb.New(time.Unix(1700000000, 0)),
+		},
+	})
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := bstream.NewDBinBlockWriter(buf)
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(&pbbstream.Block{
+		Id:        "aa",
+		Number:    100,
+		ParentId:  "bb",
+		ParentNum: 99,
+		LibNum:    99,
+		Timestamp: timestamppb.New(time.Unix(1700000000, 0)),
+		Payload:   payload,
+	}))
+
+	// truncated frame: length prefix claims 1000 bytes, only 3 follow
+	buf.Write([]byte{0x00, 0x00, 0x03, 0xe8, 0x01, 0x02, 0x03})
+
+	require.NoError(t, store.WriteObject(ctx, "0000000100", bytes.NewReader(buf.Bytes())))
+}
+
+func testCommandWithContext(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().Uint64("merged-blocks-bundle-size", 100, "")
+	cmd.SetContext(ctx)
+	return cmd
+}
+
+func TestFixAnyTypeReturnsErrorOnCorruptBundle(t *testing.T) {
+	ctx := context.Background()
+	srcURL := "file://" + t.TempDir()
+	dstURL := "file://" + t.TempDir()
+
+	srcStore, err := dstore.NewDBinStore(srcURL)
+	require.NoError(t, err)
+	writeCorruptBundle(t, ctx, srcStore)
+
+	err = createFixAnyTypeE(zap.NewNop())(testCommandWithContext(ctx), []string{srcURL, dstURL, "100", "200"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reading block")
+}
+
+func TestFindUnknownStatusReturnsErrorOnCorruptBundle(t *testing.T) {
+	ctx := context.Background()
+	srcURL := "file://" + t.TempDir()
+	dstURL := "file://" + t.TempDir()
+
+	srcStore, err := dstore.NewDBinStore(srcURL)
+	require.NoError(t, err)
+	writeCorruptBundle(t, ctx, srcStore)
+
+	err = scanForUnknownStatusE(zap.NewNop())(testCommandWithContext(ctx), []string{srcURL, dstURL, "100", "200"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reading block")
+}

--- a/cmd/fireeth/tools_sanitizer.go
+++ b/cmd/fireeth/tools_sanitizer.go
@@ -44,8 +44,8 @@ func SanitizeEthereumBlockForCompare(block *pbbstream.Block) *pbbstream.Block {
 		ethBlock.Header.TotalDifficulty = nil
 	}
 	var hasLogBloom bool
-	for _, byte := range ethBlock.Header.LogsBloom {
-		if byte != '0' {
+	for _, b := range ethBlock.Header.LogsBloom {
+		if b != 0 {
 			hasLogBloom = true
 			break
 		}
@@ -124,22 +124,14 @@ func SanitizeEthereumBlockForCompare(block *pbbstream.Block) *pbbstream.Block {
 			tx.BeginOrdinal = 0
 			tx.EndOrdinal = 0
 		}
-		var hasLogBloom bool
-		for _, byte := range tx.Receipt.LogsBloom {
-			if byte != '0' {
-				hasLogBloom = true
-				break
-			}
-		}
-		if !hasLogBloom {
-			tx.Receipt.LogsBloom = nil
-		}
 		if ignoreOrdinals {
 			for _, l := range tx.Receipt.Logs {
 				l.Ordinal = 0
 			}
 		}
 
+		// Receipt logs blooms are always removed for comparison, some producers
+		// don't fill them at all.
 		tx.Receipt.LogsBloom = nil
 		for _, call := range tx.Calls {
 			if ignoreOrdinals {

--- a/cmd/fireeth/tools_sanitizer_test.go
+++ b/cmd/fireeth/tools_sanitizer_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	firecore "github.com/streamingfast/firehose-core"
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestSanitizeEthereumBlockForCompareLogsBloom(t *testing.T) {
+	realBloom := make([]byte, 256)
+	realBloom[3] = 0x40
+	realBloom[128] = 0x01
+
+	tests := []struct {
+		name          string
+		bloom         []byte
+		expectedBloom []byte
+	}{
+		{
+			name:          "all-zero bloom is normalized to nil",
+			bloom:         make([]byte, 256),
+			expectedBloom: nil,
+		},
+		{
+			name:          "real bloom is kept",
+			bloom:         realBloom,
+			expectedBloom: realBloom,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ethBlock := &pbeth.Block{
+				Hash:   []byte{0xaa, 0xbb},
+				Number: 2,
+				Ver:    3,
+				Header: &pbeth.BlockHeader{
+					ParentHash: []byte{0xcc, 0xdd},
+					Timestamp:  timestamppb.New(time.Unix(1700000000, 0)),
+					LogsBloom:  append([]byte(nil), tt.bloom...),
+				},
+				TransactionTraces: []*pbeth.TransactionTrace{
+					{
+						Receipt: &pbeth.TransactionReceipt{
+							LogsBloom: append([]byte(nil), tt.bloom...),
+						},
+					},
+				},
+			}
+
+			blk, err := firecore.EncodeBlock(firecore.BlockEnveloppe{Block: ethBlock, LIBNum: 1})
+			require.NoError(t, err)
+
+			sanitized := SanitizeEthereumBlockForCompare(blk)
+
+			msg, err := sanitized.Payload.UnmarshalNew()
+			require.NoError(t, err)
+			ethOut, ok := msg.(*pbeth.Block)
+			require.True(t, ok)
+
+			require.Equal(t, tt.expectedBloom, ethOut.Header.LogsBloom)
+
+			// receipt logs blooms are always removed for comparison
+			require.Nil(t, ethOut.TransactionTraces[0].Receipt.LogsBloom)
+		})
+	}
+}


### PR DESCRIPTION
## Fixes

### 1. Sanitizer compared bloom bytes against ASCII `'0'` (`cmd/fireeth/tools_sanitizer.go`)

The "is bloom empty" checks compared raw bloom bytes against `'0'` (0x30) instead of `0x00`, so all-zero blooms were never normalized to `nil` — defeating the sanitizer's purpose and producing false diffs in `tools compare-blocks` between producers storing `nil` vs zero-filled blooms. The header-bloom check now compares against byte `0`. The receipt-bloom branch was dead code (an unconditional `tx.Receipt.LogsBloom = nil` a few lines below always won) and has been removed in favor of the unconditional nil, preserving behavior.

### 2. Nil block dereference on corrupt bundles (`cmd/fireeth/tools_fix_any_type.go`, `cmd/fireeth/tools_find_unknown_status.go`)

Both tools ignored non-EOF errors from `br.Read()` and immediately dereferenced the nil block, panicking on any corrupt or truncated dbin bundle. They now return the error wrapped with the offending filename.

### 3. poll-rpc-blocks emitted a protocol the console reader rejects (`cmd/fireeth/tools_poll_rpc_blocks.go`)

- The command printed `FIRE INIT 2.3` and a 5-field BLOCK line, but `codec/console_reader.go` only accepts `FIRE BLOCK` lines under protocol major version 3, and the v3 format requires `parent_num` and `timestamp_unix_nano` fields in a specific order. The tool now emits `FIRE INIT 3.0` and the exact v3 line: `FIRE BLOCK <num> <hash> <parent_num> <parent_hash> <lib_num> <timestamp_unix_nano> <b64_payload>`.
- Fixed `latest, err :=` shadowing the outer `latest`, which kept the latest-block cache at 0 and refetched `eth_blockNumber` on every iteration.

## Tests

- `TestSanitizeEthereumBlockForCompareLogsBloom`: a block with a 256-byte all-zero bloom is sanitized to `nil`; a real bloom is kept; receipt blooms are always cleared.
- `TestFixAnyTypeReturnsErrorOnCorruptBundle` / `TestFindUnknownStatusReturnsErrorOnCorruptBundle`: writes a bundle with a truncated dbin frame to a temp store and asserts the commands return an error naming the file (both panicked before the fix — verified by running the new tests against the unfixed code).
- `TestFireBlockLineParsedByConsoleReader`: round-trips a generated `FIRE BLOCK` line through `codec.NewConsoleReader` and asserts block number, hash, parent num/hash, LIB num, timestamp, and payload all parse back correctly — closing the loop between the poller and the reader.

`go test ./cmd/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
