### PR TITLE
Bump substreams: lazy + parallel store quicksave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ for instructions to keep up to date.
 ## Unreleased
 
 - Bumped `substreams` to latest `develop`.
-  - Server: store quicksave/quickload now run up to 8 stores concurrently instead of one at a time, and the streaming store marshaller serializes lazily (one KV entry at a time as the upload consumes it) instead of buffering the whole serialized store, lowering peak memory and latency when quicksaving large stores. On-disk format is unchanged.
-  - Server: new quicksave perf toggles — `SUBSTREAMS_QUICKSAVE_UNSORTED=true` skips the key sort/allocation (safe; quickload is order-independent), and `SUBSTREAMS_QUICKSAVE_COMPRESSION=none` disables zstd on the ephemeral quicksave store. Both off by default.
+  - Server: store quicksave/quickload now run up to 8 stores concurrently instead of one at a time, and quicksave streams the store lazily and unsorted (one KV entry at a time, no key sort/allocation) instead of buffering the whole serialized store, lowering peak memory and save time for large stores. On-disk format is unchanged; quickload is order-independent.
+  - Server: tier1 store loading at request start now loads up to 8 stores concurrently (size probe + download/decode) instead of one at a time.
   - Server: store quicksave now also triggers on client disconnect (context canceled), not only on graceful server shutdown, so a reconnecting client can resume without reprocessing. Only applies to production-mode requests.
   - Server: quicksave block count now counts settled blocks (normal or last-partial) instead of skipping partials entirely, so quicksave arms correctly on flash-block chains; the minimum sent-block threshold before a quicksave triggers was raised from 25 to 50.
   - Server: the `substreams request stats` log now includes the last block sent to the client (`last_sent_block_num`, `last_sent_block_id`, `last_sent_block_time`), and quicksave/quickload logs now report their duration (`save_duration` / `load_duration`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ for instructions to keep up to date.
 ## Unreleased
 
 - Bumped `substreams` to latest `develop`.
+  - Server: store quicksave/quickload now run up to 8 stores concurrently instead of one at a time, and the streaming store marshaller serializes lazily (one KV entry at a time as the upload consumes it) instead of buffering the whole serialized store, lowering peak memory and latency when quicksaving large stores. On-disk format is unchanged.
   - Server: store quicksave now also triggers on client disconnect (context canceled), not only on graceful server shutdown, so a reconnecting client can resume without reprocessing. Only applies to production-mode requests.
   - Server: quicksave block count now counts settled blocks (normal or last-partial) instead of skipping partials entirely, so quicksave arms correctly on flash-block chains; the minimum sent-block threshold before a quicksave triggers was raised from 25 to 50.
   - Server: the `substreams request stats` log now includes the last block sent to the client (`last_sent_block_num`, `last_sent_block_id`, `last_sent_block_time`), and quicksave/quickload logs now report their duration (`save_duration` / `load_duration`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for instructions to keep up to date.
 
 - Bumped `substreams` to latest `develop`.
   - Server: store quicksave/quickload now run up to 8 stores concurrently instead of one at a time, and the streaming store marshaller serializes lazily (one KV entry at a time as the upload consumes it) instead of buffering the whole serialized store, lowering peak memory and latency when quicksaving large stores. On-disk format is unchanged.
+  - Server: new quicksave perf toggles — `SUBSTREAMS_QUICKSAVE_UNSORTED=true` skips the key sort/allocation (safe; quickload is order-independent), and `SUBSTREAMS_QUICKSAVE_COMPRESSION=none` disables zstd on the ephemeral quicksave store. Both off by default.
   - Server: store quicksave now also triggers on client disconnect (context canceled), not only on graceful server shutdown, so a reconnecting client can resume without reprocessing. Only applies to production-mode requests.
   - Server: quicksave block count now counts settled blocks (normal or last-partial) instead of skipping partials entirely, so quicksave arms correctly on flash-block chains; the minimum sent-block threshold before a quicksave triggers was raised from 25 to 50.
   - Server: the `substreams request stats` log now includes the last block sent to the client (`last_sent_block_num`, `last_sent_block_id`, `last_sent_block_time`), and quicksave/quickload logs now report their duration (`save_duration` / `load_duration`).

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.19.1-0.20260703191612-042ed978a2bc
+	github.com/streamingfast/substreams v1.19.1-0.20260706152812-c539b4a4f5dc
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.19.1-0.20260706165623-25be20c3756e
+	github.com/streamingfast/substreams v1.19.1-0.20260706184107-5a35d25e98db
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.19.1-0.20260706152812-c539b4a4f5dc
+	github.com/streamingfast/substreams v1.19.1-0.20260706160538-d2f7f322b288
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.19.1-0.20260706160538-d2f7f322b288
+	github.com/streamingfast/substreams v1.19.1-0.20260706165623-25be20c3756e
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -2343,8 +2343,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.19.1-0.20260706165623-25be20c3756e h1:VL/XNFMyDtNnKA0FuLcPRTNRyPP81gRkr1uCUzmr51E=
-github.com/streamingfast/substreams v1.19.1-0.20260706165623-25be20c3756e/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
+github.com/streamingfast/substreams v1.19.1-0.20260706184107-5a35d25e98db h1:NU1Y6CnxP/099SoZeaTFIcBI/fJWA5pamoJKpSVMn3Y=
+github.com/streamingfast/substreams v1.19.1-0.20260706184107-5a35d25e98db/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=

--- a/go.sum
+++ b/go.sum
@@ -2343,8 +2343,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.19.1-0.20260706152812-c539b4a4f5dc h1:3DX0NFkmgPl8GP6rPJQpnvzX69kU/WEnvTU61x2Kf64=
-github.com/streamingfast/substreams v1.19.1-0.20260706152812-c539b4a4f5dc/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
+github.com/streamingfast/substreams v1.19.1-0.20260706160538-d2f7f322b288 h1:ICsVLD/4emNaU5eD9wYk7RfEbIyxeiC2UWFSG0dOFec=
+github.com/streamingfast/substreams v1.19.1-0.20260706160538-d2f7f322b288/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=

--- a/go.sum
+++ b/go.sum
@@ -2343,8 +2343,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.19.1-0.20260703191612-042ed978a2bc h1:fCVYq6wDws9LA7P2UmEQgQ094IrxM9CncvoTLSxcuRw=
-github.com/streamingfast/substreams v1.19.1-0.20260703191612-042ed978a2bc/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
+github.com/streamingfast/substreams v1.19.1-0.20260706152812-c539b4a4f5dc h1:3DX0NFkmgPl8GP6rPJQpnvzX69kU/WEnvTU61x2Kf64=
+github.com/streamingfast/substreams v1.19.1-0.20260706152812-c539b4a4f5dc/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=

--- a/go.sum
+++ b/go.sum
@@ -2343,8 +2343,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.19.1-0.20260706160538-d2f7f322b288 h1:ICsVLD/4emNaU5eD9wYk7RfEbIyxeiC2UWFSG0dOFec=
-github.com/streamingfast/substreams v1.19.1-0.20260706160538-d2f7f322b288/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
+github.com/streamingfast/substreams v1.19.1-0.20260706165623-25be20c3756e h1:VL/XNFMyDtNnKA0FuLcPRTNRyPP81gRkr1uCUzmr51E=
+github.com/streamingfast/substreams v1.19.1-0.20260706165623-25be20c3756e/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `substreams` to `c539b4a4` (branch [`feature/quicksave-lazy-stream`](https://github.com/streamingfast/substreams/pull/822)) to pick up:

- **Lazy streaming store marshal** — serializes one KV entry at a time as the upload consumes it, instead of buffering the whole serialized store up front. Lowers peak memory when quicksaving large stores.
- **Bounded-parallel quicksave/quickload** — up to 8 stores concurrently instead of one at a time. Cuts shutdown/resume latency for pipelines with many stores.

On-disk quicksave format is **unchanged** (byte-compatible protobuf, same `.quicksave` filename) — no migration, old/new binaries interop.

Opened primarily to trigger a CI build. Depends on streamingfast/substreams#822; re-pin to the merged develop commit once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)