### PR TITLE
Drop executed_code side effect from noop-code-change sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ for instructions to keep up to date.
 
 ### Fixed
 
+- `fireeth tools compare-blocks` with `FIREETH_TOOLS_COMPARE_IGNORE_NOOP_CODE_CHANGES=true` no longer reports spurious `executed_code` differences. The noop-code-change sanitizer was force-setting `call.ExecutedCode = true` on any call carrying a noop code change (`OldHash == NewHash`, e.g. an EIP-7702 delegation revoke/re-delegate). Because the sanitizer runs per-block on each stream independently, this fired only on the side that actually emitted the noop code change, manufacturing an `executed_code` diff where the raw blocks agreed.
 - `fireeth tools print merged-blocks <store>` no longer truncates its output when a merged-blocks file is missing (open range with no explicit stop, or a bounded range extending past the last available file): with the bumped `bstream` dependency it now prints every available block first, instead of discarding in-flight files on an async shutdown. On an open range it caps the stream at the last available merged-blocks file (found with an `O(log n)` existence probe rather than a full store listing) so it stops cleanly instead of erroring on the expected-missing next file. Also fixes an off-by-one that stopped one block early on a closed range, and a potential unsigned underflow when a closed range ends at block 0.
 
 ## v2.18.0

--- a/cmd/fireeth/tools_sanitizer_noop_code_changes.go
+++ b/cmd/fireeth/tools_sanitizer_noop_code_changes.go
@@ -54,7 +54,6 @@ func collectNoopCodeChangeOrdinals(block *pbeth.Block) []uint64 {
 		for _, call := range trace.Calls {
 			for _, codeChange := range call.CodeChanges {
 				if codeChange.Ordinal > 0 && isNoopCodeChange(codeChange) {
-					call.ExecutedCode = true
 					out = append(out, codeChange.Ordinal)
 				}
 			}


### PR DESCRIPTION
## Problem

`fireeth tools compare-blocks` run with `FIREETH_TOOLS_COMPARE_IGNORE_NOOP_CODE_CHANGES=true` reports spurious `executed_code` differences.

`collectNoopCodeChangeOrdinals` force-set `call.ExecutedCode = true` on any call carrying a noop code change (`OldHash == NewHash` — e.g. an EIP-7702 delegation revoke/re-delegate that writes empty→empty). Because `SanitizeEthereumBlockForCompare` runs per-block on each stream independently, the mutation only fired on the side that actually emitted the noop code change (geth emits empty→empty entries reth omits), fabricating an `executed_code` diff where the raw blocks agreed.

Concretely, on Hoodi block 3172734 tx `0xe828877f…` (a 7702 revoke-to-zero): reth's call carries no code change, geth's carries a redundant empty→empty one. The flag stripped the code-change diff but, as a side effect, converted it into a phantom `executed_code: true` diff.

## Fix

Remove the `call.ExecutedCode = true` mutation from the collect pass. The noop-code-change stripping is unchanged.

## Verified

- Confirmed in a battlefield geth-dev vs reth-dev run that both clients emit `executed_code: false` for the 7702 revoke-to-zero shape — reth's value is correct; the diff was purely the sanitizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)