### PR TITLE
bump bstream: fix firehose lag on flash/partial-block chains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260520032149-6421410d7faa
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.15.1-0.20260707190949-bae2bd775b2a
+	github.com/streamingfast/firehose-core v1.15.1-0.20260709183229-e2550ebe559b
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437

--- a/go.mod
+++ b/go.mod
@@ -15,14 +15,14 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
-	github.com/streamingfast/bstream v0.0.2-0.20260707150341-487b28967227
+	github.com/streamingfast/bstream v0.0.2-0.20260709191130-aecaf73e1c32
 	github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b
 	github.com/streamingfast/derr v0.0.0-20250814163534-bd7407bd89d7
 	github.com/streamingfast/dmetrics v0.0.0-20260109212625-35256f512c62
 	github.com/streamingfast/dstore v0.2.4-0.20260520032149-6421410d7faa
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.15.1-0.20260709183229-e2550ebe559b
+	github.com/streamingfast/firehose-core v1.15.1-0.20260707190949-bae2bd775b2a
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437

--- a/go.sum
+++ b/go.sum
@@ -2312,8 +2312,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.15.1-0.20260707190949-bae2bd775b2a h1:x5MlMZcnhLJPm97gGWcH1siFXgKC0gcdkEpGf5L+BU4=
-github.com/streamingfast/firehose-core v1.15.1-0.20260707190949-bae2bd775b2a/go.mod h1:yDI/I5+GjMQZ/4jVqfe1Gk5Kct7cR6Bt8Mk4qI91NEI=
+github.com/streamingfast/firehose-core v1.15.1-0.20260709183229-e2550ebe559b h1:05XxGVnxB0OiAhDa0ukGyLI0i6ZANRL+0KBVqxVlOdo=
+github.com/streamingfast/firehose-core v1.15.1-0.20260709183229-e2550ebe559b/go.mod h1:yDI/I5+GjMQZ/4jVqfe1Gk5Kct7cR6Bt8Mk4qI91NEI=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=

--- a/go.sum
+++ b/go.sum
@@ -2280,8 +2280,8 @@ github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjb
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
-github.com/streamingfast/bstream v0.0.2-0.20260707150341-487b28967227 h1:6fW2sABAeYFd+Yd46D4CgNtwpgVz4WwV2wXez8n3QJk=
-github.com/streamingfast/bstream v0.0.2-0.20260707150341-487b28967227/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
+github.com/streamingfast/bstream v0.0.2-0.20260709191130-aecaf73e1c32 h1:lXdt7nh4oP3+x+uf+E/R3GkZ1gvUOldFIJLMMxhjupk=
+github.com/streamingfast/bstream v0.0.2-0.20260709191130-aecaf73e1c32/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b h1:ztYeX3/5rg2tV2EU7edcrcHzMz6wUbdJB+LqCrP5W8s=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b/go.mod h1:o9R/tjNON01X2mgWL5qirl2MV6xQ4EZI5D504ST3K/M=
 github.com/streamingfast/dauth v0.0.0-20260318230957-4ab1e1d2ebc3 h1:Zo2daSGDUPoK32w9G1e9fZO3Q6b5Cvu5ZojdoD/Wgp8=
@@ -2312,6 +2312,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
+github.com/streamingfast/firehose-core v1.15.1-0.20260707190949-bae2bd775b2a h1:x5MlMZcnhLJPm97gGWcH1siFXgKC0gcdkEpGf5L+BU4=
+github.com/streamingfast/firehose-core v1.15.1-0.20260707190949-bae2bd775b2a/go.mod h1:yDI/I5+GjMQZ/4jVqfe1Gk5Kct7cR6Bt8Mk4qI91NEI=
 github.com/streamingfast/firehose-core v1.15.1-0.20260709183229-e2550ebe559b h1:05XxGVnxB0OiAhDa0ukGyLI0i6ZANRL+0KBVqxVlOdo=
 github.com/streamingfast/firehose-core v1.15.1-0.20260709183229-e2550ebe559b/go.mod h1:yDI/I5+GjMQZ/4jVqfe1Gk5Kct7cR6Bt8Mk4qI91NEI=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=


### PR DESCRIPTION
Bumps `bstream` to include the hub-subscription fix (streamingfast/bstream#60).

## Why

On flash/partial-block chains the firehose served blocks with large gaps (tens of seconds between consecutive numbers). Its live source subscribes with `with_partials=false`, and the hub dropped the closing `LastPartial` along with intermediate partials — so the firehose only advanced on the lagging separate full block, bridging the rest from one-block files.

The `bstream` fix delivers each `LastPartial` to a no-partial subscriber as a full block (partial markers cleared on a thin copy), so the head keeps advancing without ever exposing partial semantics to clients.

Dependency-only change (`go.mod`/`go.sum`); `firehose-core` stays on develop since the fix is entirely in `bstream`, which is pinned directly here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)