### PR TITLE
Bump dstore for S3 request checksum fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ for instructions to keep up to date.
 
 ### Fixed
 
+- Bumped `dstore` to send S3 request checksums when the target bucket/endpoint requires them, fixing writes that failed against S3-compatible stores enforcing `x-amz-sdk-checksum-algorithm` on uploads.
+
 - `fireeth tools print merged-blocks <store>` no longer truncates its output when a merged-blocks file is missing (open range with no explicit stop, or a bounded range extending past the last available file): with the bumped `bstream` dependency it now prints every available block first, instead of discarding in-flight files on an async shutdown. On an open range it caps the stream at the last available merged-blocks file (found with an `O(log n)` existence probe rather than a full store listing) so it stops cleanly instead of erroring on the expected-missing next file. Also fixes an off-by-one that stopped one block early on a closed range, and a potential unsigned underflow when a closed range ends at block 0.
 
 ## v2.18.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b
 	github.com/streamingfast/derr v0.0.0-20250814163534-bd7407bd89d7
 	github.com/streamingfast/dmetrics v0.0.0-20260109212625-35256f512c62
-	github.com/streamingfast/dstore v0.2.4-0.20260520032149-6421410d7faa
+	github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
 	github.com/streamingfast/firehose-core v1.15.1-0.20260707190949-bae2bd775b2a

--- a/go.sum
+++ b/go.sum
@@ -2304,6 +2304,8 @@ github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58 h1:at7VPRhG
 github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58/go.mod h1:ldDwFqr20xXyaLhwDm7XlMaf2vvoZNOrjgsMcFJGtrw=
 github.com/streamingfast/dstore v0.2.4-0.20260520032149-6421410d7faa h1:0J6uKpYH4mdDp8LkYB4YqZyrhNDuQmFCLxOmKgBojxU=
 github.com/streamingfast/dstore v0.2.4-0.20260520032149-6421410d7faa/go.mod h1:TMunfchUOefhTu+X2a81fPMW0F4/cGNNdihXIaChpJI=
+github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902 h1:vmSOeUk0Q56YLeVuYqYwmQEfPvq6guLbRRuVrWo8j2Y=
+github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902/go.mod h1:TMunfchUOefhTu+X2a81fPMW0F4/cGNNdihXIaChpJI=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9 h1:RaMv0J2e30vQpJiKdWOGB1HObWtJ4/w4vEUkUhTYE+c=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9/go.mod h1:huOJyjMYS6K8upTuxDxaNd+emD65RrXoVBvh8f1/7Ns=
 github.com/streamingfast/dummy-blockchain v1.7.3 h1:rPheajbwc+hwh4XVRMaroET/p/lvlI7WGfqETBkIL18=


### PR DESCRIPTION
Bumps `dstore` to branch `fix/s3-request-checksum-when-required`, which sends S3 request checksums when the target bucket/endpoint requires them (fixes uploads failing against S3-compatible stores that enforce `x-amz-sdk-checksum-algorithm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)