### PR TITLE
Fix docker: arch-suffix per-arch image tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,13 +83,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
             type=ref,event=tag,suffix=-${{ matrix.architecture }}
-            type=sha,prefix=
             type=sha,prefix=,suffix=-${{ matrix.architecture }}
-            type=raw,enable=${{ github.ref == 'refs/heads/develop' }},value=develop
+            type=sha,prefix=,enable=${{ matrix.architecture == 'amd64' }}
+            type=raw,enable=${{ github.ref == 'refs/heads/develop' }},value=develop,suffix=-${{ matrix.architecture }}
           flavor: |
-            latest=${{ startsWith(github.ref, 'refs/tags/') }}
+            latest=false
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Problem

The docker workflow builds `amd64` and `arm64` in a matrix. Both runners pushed the **same unsuffixed** tags (`v1.2.3`, `<sha>`, `develop`) via `metadata-action`, so the two arch runners raced to overwrite each other on those tags.

## Fix

Per-arch matrix runners now push **only arch-suffixed** tags (`v1.2.3-amd64` / `v1.2.3-arm64`, `<sha>-arch`, `develop-arch`) with `latest=false`. Single writer per tag → no race.

The existing `push` (manifest) job still creates the clean unsuffixed multi-arch tags (`v1.2.3`, `<sha>`, `develop`, `latest`) by stitching the two `<sha>-arch` images together — unchanged, already references those images.

Additionally, the `amd64` runner publishes the unsuffixed short-sha tag (single writer; manifest job later overwrites it with the multi-arch manifest).