### PR TITLE
Reuse HTTP connections for Substreams RPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md)
 for instructions to keep up to date.
 
+## Unreleased
+
+### Changed
+
+- Substreams RPC calls (`eth_call` and `eth_getBalance`) now reuse their HTTP connections instead of opening a new one for every batch.
+
+  Connections were explicitly never reused, so each batch paid a full DNS resolution, TCP handshake and TLS handshake before the endpoint did any work, which on a remote provider easily adds 100ms or more per batch. The connection pool is now also held by the extension itself rather than by the RPC engine, since Substreams builds a new engine for every tier2 job: a per engine pool could never be reused across jobs, and left its idle connections behind when the job ended.
+
+  Use `--substreams-rpc-max-idle-conns-per-host` (default `100`) and `--substreams-rpc-idle-conn-timeout` (default `90s`) to size the pool. Note that Go's own default of 2 idle connections per host is far too low for this workload, hence the higher default.
+
+  Set `--substreams-rpc-disable-keep-alives` to restore the previous behavior. This is only needed when a single endpoint hostname fronts a pool of nodes through round-robin DNS and spreading the load across them matters more than the handshake cost.
+
 ## v2.19.1
 
 ### Added

--- a/cmd/fireeth/main.go
+++ b/cmd/fireeth/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -77,6 +78,10 @@ func Chain() *firecore.Chain[*pbeth.Block] {
 			flags.StringArray("substreams-rpc-endpoints", nil, "Remote endpoints to contact to satisfy Substreams 'eth_call's")
 			flags.StringArray("substreams-rpc-get-balance-endpoints", nil, "Endpoints to contact to satisfy Substreams 'eth_get_balance's")
 			flags.Uint64("substreams-rpc-gas-limit", 50_000_000, "Gas limit to set when calling RPC (set it to 0 for arbitrum chains, otherwise you should keep 50M)")
+
+			flags.Int("substreams-rpc-max-idle-conns-per-host", 100, "Maximum number of idle connections kept alive per Substreams RPC endpoint, raise it if you serve more concurrent requests than that per endpoint")
+			flags.Duration("substreams-rpc-idle-conn-timeout", 90*time.Second, "How long an unused connection to a Substreams RPC endpoint is kept alive before being closed")
+			flags.Bool("substreams-rpc-disable-keep-alives", false, "Never reuse a connection to a Substreams RPC endpoint, making every batch pay a new TCP and TLS handshake. Only needed when a single endpoint hostname fronts a pool of nodes through round-robin DNS")
 		},
 
 		RegisterSubstreamsExtensions: func() (wasm.WASMExtensioner, error) {
@@ -120,7 +125,11 @@ func Chain() *firecore.Chain[*pbeth.Block] {
 			if hasEndpoints(balanceEndpoints) {
 				extensions["rpc_eth_get_balance"] = balData
 			}
-			return ethss.NewRPCExtensioner(extensions), nil
+			return ethss.NewRPCExtensioner(extensions, ethss.ConnectionOptions{
+				MaxIdleConnsPerHost: viper.GetInt("substreams-rpc-max-idle-conns-per-host"),
+				IdleConnTimeout:     viper.GetDuration("substreams-rpc-idle-conn-timeout"),
+				DisableKeepAlives:   viper.GetBool("substreams-rpc-disable-keep-alives"),
+			}), nil
 		},
 
 		ReaderNodeBootstrapperFactory: firecore.DefaultReaderNodeBootstrapper(newReaderNodeBootstrapper),

--- a/substreams/rpccalls.go
+++ b/substreams/rpccalls.go
@@ -26,12 +26,55 @@ const EthCallFallbackDurationEnvVar = "ETH_CALL_FALLBACK_TO_LATEST_DURATION"
 
 // interfaces, living in `streamingfast/substreams:extensions.go`
 
-type RPCExtensioner struct {
-	params map[string]string
+// ConnectionOptions tunes the HTTP connection pool used to reach the RPC endpoints.
+type ConnectionOptions struct {
+	// MaxIdleConnsPerHost is how many idle connections are kept around per endpoint. The Go
+	// default of 2 is far too low here: past that, connections are closed after each request
+	// and every batch pays a fresh handshake again.
+	MaxIdleConnsPerHost int
+	// IdleConnTimeout is how long an unused connection is kept before being closed.
+	IdleConnTimeout time.Duration
+	// DisableKeepAlives restores the previous behavior of never reusing a connection. Needed
+	// only when a single endpoint hostname fronts a pool of nodes through round-robin DNS and
+	// spreading the load across them matters more than the handshake cost.
+	DisableKeepAlives bool
 }
 
-func NewRPCExtensioner(params map[string]string) *RPCExtensioner {
-	return &RPCExtensioner{params: params}
+func DefaultConnectionOptions() ConnectionOptions {
+	return ConnectionOptions{
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+	}
+}
+
+// NewHTTPClient builds the HTTP client reaching the RPC endpoints.
+//
+// The returned client, and more importantly its underlying transport holding the connection
+// pool, is meant to be shared by every RPC engine of the process. Substreams builds a fresh
+// engine for each tier2 job it processes, so a per engine transport would keep the pool from
+// ever being reused across jobs, and would strand its idle connections when the job ends.
+func NewHTTPClient(opts ConnectionOptions) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	// The per host cap is the one that matters, all the load goes to a handful of endpoints.
+	transport.MaxIdleConns = 0
+	transport.MaxIdleConnsPerHost = opts.MaxIdleConnsPerHost
+	transport.IdleConnTimeout = opts.IdleConnTimeout
+	transport.DisableKeepAlives = opts.DisableKeepAlives
+
+	return &http.Client{Transport: transport}
+}
+
+type RPCExtensioner struct {
+	params     map[string]string
+	httpClient *http.Client
+}
+
+func NewRPCExtensioner(params map[string]string, opts ConnectionOptions) *RPCExtensioner {
+	return &RPCExtensioner{
+		params:     params,
+		httpClient: NewHTTPClient(opts),
+	}
 }
 
 func (e *RPCExtensioner) Params() map[string]string {
@@ -86,7 +129,7 @@ func (e *RPCExtensioner) WASMExtensions(in map[string]string) (map[string]map[st
 		}
 	}
 
-	eng, err := NewRPCEngine(callURLs, balURLs, gasLimit)
+	eng, err := NewRPCEngine(callURLs, balURLs, gasLimit, WithHTTPClient(e.httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("creating new RPC engine: %w", err)
 	}
@@ -116,18 +159,38 @@ type RPCEngine struct {
 	currentBalanceClientIndex int
 }
 
-func NewRPCEngine(callEndpoints []string, balanceEndpoints []string, gasLimit uint64) (*RPCEngine, error) {
+// EngineOption customizes an [RPCEngine].
+type EngineOption func(*engineConfig)
+
+type engineConfig struct {
+	httpClient *http.Client
+}
+
+// WithHTTPClient makes the engine use the given HTTP client, and through it the connection
+// pool shared with the other engines of the process.
+func WithHTTPClient(httpClient *http.Client) EngineOption {
+	return func(config *engineConfig) {
+		config.httpClient = httpClient
+	}
+}
+
+func NewRPCEngine(callEndpoints []string, balanceEndpoints []string, gasLimit uint64, options ...EngineOption) (*RPCEngine, error) {
 	zlog.Debug("creating new Substreams RPC engine",
 		zap.Strings("call_endpoints", callEndpoints),
 		zap.Strings("get_balance_endpoints", balanceEndpoints),
 		zap.Uint64("gas_limit", gasLimit),
 	)
 
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			DisableKeepAlives: true, // don't reuse connections
-		},
+	config := &engineConfig{}
+	for _, option := range options {
+		option(config)
 	}
+
+	httpClient := config.httpClient
+	if httpClient == nil {
+		httpClient = NewHTTPClient(DefaultConnectionOptions())
+	}
+
 	opts := []rpc.Option{
 		rpc.WithHttpClient(httpClient),
 	}

--- a/substreams/rpccalls_test.go
+++ b/substreams/rpccalls_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1002,4 +1003,96 @@ func TestRPCEngine_rpcCalls_fallbackOverridesBlockNumber(t *testing.T) {
 			{Raw: eth.MustNewBytes("0x0000000000000000000000000000000000000000000000000000000000000012"), Failed: false},
 		},
 	}, responses)
+}
+
+// countingConnServer is an HTTP test server counting how many distinct TCP connections it
+// accepted, which is what tells connection reuse apart from connection churn.
+func countingConnServer(t *testing.T) (*httptest.Server, func() int) {
+	t.Helper()
+
+	var mutex sync.Mutex
+	connections := map[net.Conn]bool{}
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"jsonrpc":"2.0","id":"0x1","result":"0x0000000000000000000000000000000000000000000000000000000000000012"}`))
+	}))
+
+	server.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state != http.StateNew {
+			return
+		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
+		connections[conn] = true
+	}
+
+	server.Start()
+	t.Cleanup(server.Close)
+
+	return server, func() int {
+		mutex.Lock()
+		defer mutex.Unlock()
+		return len(connections)
+	}
+}
+
+func callEngineTimes(t *testing.T, engine *RPCEngine, times int) {
+	t.Helper()
+
+	address := eth.MustNewAddress("0xea674fdde714fd979de3edf0f56aa9716b898ec8")
+	data := eth.MustNewMethodDef("decimals()").MethodID()
+
+	protoCalls, err := proto.Marshal(&pbethss.RpcCalls{Calls: []*pbethss.RpcCall{{ToAddr: address, Data: data}}})
+	require.NoError(t, err)
+
+	for range times {
+		_, _, err := engine.ethCall(context.Background(), 0, "someTraceID", clockBlock1, protoCalls)
+		require.NoError(t, err)
+	}
+}
+
+func TestRPCEngineReusesConnections(t *testing.T) {
+	server, connectionCount := countingConnServer(t)
+
+	engine, err := NewRPCEngine([]string{server.URL}, []string{server.URL}, 50_000_000)
+	require.NoError(t, err)
+
+	callEngineTimes(t, engine, 5)
+
+	assert.Equal(t, 1, connectionCount(), "the 5 batches should all have gone through a single connection")
+}
+
+func TestRPCEngineDisableKeepAlives(t *testing.T) {
+	server, connectionCount := countingConnServer(t)
+
+	httpClient := NewHTTPClient(ConnectionOptions{DisableKeepAlives: true})
+	engine, err := NewRPCEngine([]string{server.URL}, []string{server.URL}, 50_000_000, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	callEngineTimes(t, engine, 5)
+
+	assert.Equal(t, 5, connectionCount(), "opting out of keep-alives must go back to one connection per batch")
+}
+
+// Substreams builds a new engine for every tier2 job, so the pool only ever gets reused if it
+// lives on the extensioner rather than on the engine.
+func TestRPCExtensionerSharesConnectionsAcrossEngines(t *testing.T) {
+	server, connectionCount := countingConnServer(t)
+
+	extensioner := NewRPCExtensioner(map[string]string{
+		"rpc_eth_call": fmt.Sprintf("50000000,%s", server.URL),
+	}, DefaultConnectionOptions())
+
+	for range 3 {
+		_, err := extensioner.WASMExtensions(extensioner.Params())
+		require.NoError(t, err)
+
+		engine, err := NewRPCEngine([]string{server.URL}, nil, 50_000_000, WithHTTPClient(extensioner.httpClient))
+		require.NoError(t, err)
+
+		callEngineTimes(t, engine, 2)
+	}
+
+	assert.Equal(t, 1, connectionCount(), "engines built from the same extensioner must share the connection pool")
 }


### PR DESCRIPTION
## Problem

Substreams RPC calls never reused their HTTP connections. `substreams/rpccalls.go` built its client with `DisableKeepAlives: true`, introduced in 2022 by the commit that *moved* this code over from the substreams repo, carrying only a `// don't reuse connections` comment and no rationale.

Every `eth_call` / `eth_getBalance` batch therefore paid a DNS resolution, a TCP handshake and a TLS handshake before the endpoint did any work. On a remote provider that is easily 100ms+ of pure setup per batch, plus TIME_WAIT accumulation and ephemeral port pressure on busy tier2 fleets.

There is a second, compounding problem. Substreams calls `WASMExtensions` from inside `processRange`, i.e. **once per tier2 job**, which ran `NewRPCEngine` and built a brand new `http.Transport` each time. So even with keep-alives enabled, a pool held by the engine could never be reused across jobs, and stranded its idle connections when the job ended. Tier2 does the overwhelming bulk of the `eth_call` traffic during backprocessing, so that is exactly where it hurt most.

## Change

- Enable connection reuse, with `MaxIdleConnsPerHost` and `IdleConnTimeout` exposed as flags. Go's own default of **2** idle connections per host is far too low for this workload — past that, connections are closed after each request and the churn comes right back — hence the default of 100.
- Move the pool to the `RPCExtensioner`, which Substreams keeps for the life of the process, so all the engines it builds share one pool.
- Keep an escape hatch, `--substreams-rpc-disable-keep-alives`, for the case that plausibly motivated the original code: a single endpoint hostname fronting a pool of nodes through round-robin DNS, where pooling pins traffic to one backend.

## Flags

| Flag | Default |
| --- | --- |
| `--substreams-rpc-max-idle-conns-per-host` | `100` |
| `--substreams-rpc-idle-conn-timeout` | `90s` |
| `--substreams-rpc-disable-keep-alives` | `false` |

## Tests

Three new tests counting distinct TCP connections accepted by an `httptest` server:

- `TestRPCEngineReusesConnections` — 5 batches now go through **1** connection.
- `TestRPCEngineDisableKeepAlives` — the opt-out still yields **5**, pinning the old behavior.
- `TestRPCExtensionerSharesConnectionsAcrossEngines` — engines built from one extensioner share the pool, covering the per-tier2-job regression.

## Risk

This is a behavior change under load. If any configured provider relies on round-robin DNS to spread load, pooling will pin traffic to whichever backend was resolved first; `--substreams-rpc-disable-keep-alives` reverts to the previous behavior without a redeploy of anything else.

Worth noting there is currently **no** instrumentation on this path, so the improvement cannot be observed directly yet — a separate RPC call stats change is in progress and would make the before/after measurable.