### PR TITLE
tools poller: multiple RPC providers with per-provider headers and periodic failback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ for instructions to keep up to date.
 
 - `tools poller`: a malformed `--headers` entry (no `:` separator, or an empty key) is now refused at startup instead of being silently ignored, which used to make the endpoint reject requests for a missing credential that looked like it had been provided.
 
+- `tools poller`: `--headers` no longer splits its value on commas, it declares a single header and is repeated to send more than one. A header with a comma in its value (`-H "Accept-Encoding: gzip, deflate"`) used to be split into `Accept-Encoding: gzip` and a ` deflate` fragment that was silently dropped, which combined with the startup validation above would now have refused to start. Passing several headers in a single comma-separated `--headers` value no longer works, use one flag per header.
+
 - `tools poller`: block fetch errors now name the provider they came from (`provider "primary": ...`) and rolling to a fallback provider is logged as `rolling to next RPC provider` with the `from_provider` and `to_provider` names.
 
 - `tools poller`: the `launching firehose-ethereum poller` log line now reports the providers by name with their URL redacted (`rpc_providers: ["primary=https://primary.example.com/redacted"]`) instead of printing the full endpoint URL, which leaked the API key embedded in it in cleartext.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,35 @@ for instructions to keep up to date.
 
 ## Unreleased
 
+### Added
+
+- `tools poller`: new repeatable `--provider=<url>[#<name>]` flag, declaring the RPC providers to poll blocks from. The flag order is the priority order: the first provider is the preferred one and the next ones are used as fallback when it errors out. The name, taken after the last `#` of the value, defaults to the URL's host and is what identifies the provider in logs and in `--headers`.
+
+  The `<rpc-endpoint>` positional argument is now optional, so both forms work and can be combined, a positional endpoint always being the highest priority provider, named `default`:
+
+  ```
+  fireeth tools poller optimism https://endpoint.example.com 1000
+
+  fireeth tools poller optimism 1000 \
+    --provider=https://primary.example.com/v1/key#primary \
+    --provider=https://fallback.example.com/key#fallback
+  ```
+
+  Duplicate provider names are refused at startup.
+
+- `tools poller`: new `--providers-failback-interval` flag (default `10m`) which periodically re-prefers the declared provider order. The rolling strategy used by the poller is sticky forever, so a single transient error on the preferred provider used to move polling to a fallback provider until the process was restarted, which for a paid fallback endpoint meant paying for it full-time after a momentary blip. Set it to `0` to keep the previous behavior.
+
 ### Changed
+
+- `tools poller`: `--headers` entries can now be scoped to a single provider by suffixing them with `#<provider-name>`, as in `--headers="Authorization: Bearer xyz#fallback"`. Entries without a `#` keep applying to every provider, so existing invocations are unchanged. An entry scoped to an unknown provider name is refused at startup rather than being silently dropped.
+
+  The provider name is taken after the **last** `#` of the value, so a header value legitimately ending with `#<something>` is going to be mis-parsed. There is no escaping syntax.
+
+- `tools poller`: a malformed `--headers` entry (no `:` separator, or an empty key) is now refused at startup instead of being silently ignored, which used to make the endpoint reject requests for a missing credential that looked like it had been provided.
+
+- `tools poller`: block fetch errors now name the provider they came from (`provider "primary": ...`) and rolling to a fallback provider is logged as `rolling to next RPC provider` with the `from_provider` and `to_provider` names.
+
+- `tools poller`: the `launching firehose-ethereum poller` log line now reports the providers by name with their URL redacted (`rpc_providers: ["primary=https://primary.example.com/redacted"]`) instead of printing the full endpoint URL, which leaked the API key embedded in it in cleartext.
 
 - Substreams RPC calls (`eth_call` and `eth_getBalance`) now reuse their HTTP connections instead of opening a new one for every batch.
 

--- a/cmd/fireeth/poller.go
+++ b/cmd/fireeth/poller.go
@@ -42,6 +42,9 @@ func newPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 			    --headers="X-Api-Key: shared"                  sent to every provider
 			    --headers="Authorization: Bearer xyz#primary"  sent only to the "primary" provider
 
+			'--headers' declares a single header and is repeated to send more than one, its value
+			being taken verbatim, commas included.
+
 			Since both suffixes are taken after the last '#', a URL or a header value legitimately
 			ending with '#<something>' is going to be mis-parsed, there is no escaping syntax. A
 			'#' anywhere else in the value, like in the middle of an API key, is left alone.
@@ -60,7 +63,7 @@ func newPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	cmd.PersistentFlags().Uint("parallel-workers", 20, "number of parallel workers to fetch transaction receipts")
 	cmd.PersistentFlags().Uint("block-fetch-batch-size", 1, "number of blocks to fetch (and serialize) in parallel")
 	cmd.PersistentFlags().StringArray("provider", nil, "RPC provider to poll blocks from, in the form '<url>[#<name>]', repeat the flag to declare multiple providers, the flag order being the priority order (first one preferred, next ones used as fallback). The name defaults to the URL's host and is what identifies the provider in logs and in '--headers'. It is taken after the last '#' of the value")
-	cmd.PersistentFlags().StringSliceP("headers", "H", nil, "headers to send with each request, either 'Key: Value' to send it to every provider or 'Key: Value#<provider-name>' to send it only to that provider (ex: '-H \"key1: value1\" -H \"Authorization: Bearer xyz#fallback\"'). The provider name is taken after the last '#' of the value, so a header value legitimately ending with '#<something>' is going to be mis-parsed, there is no escaping syntax")
+	cmd.PersistentFlags().StringArrayP("headers", "H", nil, "header to send with each request, either 'Key: Value' to send it to every provider or 'Key: Value#<provider-name>' to send it only to that provider, repeat the flag to send multiple headers (ex: '-H \"key1: value1\" -H \"Authorization: Bearer xyz#fallback\"'). The value is taken verbatim, commas included. The provider name is taken after the last '#' of the value, so a header value legitimately ending with '#<something>' is going to be mis-parsed, there is no escaping syntax")
 	cmd.PersistentFlags().Duration("providers-failback-interval", 10*time.Minute, "interval at which the declared provider order is re-preferred, moving polling back to the preferred provider after a transient error moved it to a fallback one. Set to 0 to stick to the fallback provider until the process is restarted")
 	cmd.PersistentFlags().Bool("allow-empty-receipts-on-block-0", false, "whether to accept empty receipts on block 0, filling them with 'empty' transactions (useful for TRON-EVM)")
 
@@ -166,7 +169,7 @@ func pollerRunEInternal(logger *zap.Logger, tracer logging.Tracer, useTracer boo
 			return fmt.Errorf("unable to parse first streamable block %q: %w", firstStreamableBlockArg, err)
 		}
 
-		providers, err := rpcprovider.Parse(rpcEndpoint, sflags.MustGetStringArray(cmd, "provider"), sflags.MustGetStringSlice(cmd, "headers"))
+		providers, err := rpcprovider.Parse(rpcEndpoint, sflags.MustGetStringArray(cmd, "provider"), sflags.MustGetStringArray(cmd, "headers"))
 		if err != nil {
 			return err
 		}

--- a/cmd/fireeth/poller.go
+++ b/cmd/fireeth/poller.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -15,6 +14,7 @@ import (
 	"github.com/streamingfast/firehose-core/blockpoller"
 	firecorerpc "github.com/streamingfast/firehose-core/rpc"
 	"github.com/streamingfast/firehose-ethereum/blockfetcher"
+	"github.com/streamingfast/firehose-ethereum/cmd/fireeth/rpcprovider"
 	"github.com/streamingfast/logging"
 	"go.uber.org/zap"
 )
@@ -23,11 +23,45 @@ func newPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "poller",
 		Short: "poll blocks from different sources",
+		Long: cli.Dedent(`
+			Polls blocks from one or more RPC providers. The first provider is the preferred one,
+			the next ones are used as fallback when the preferred one errors out.
+
+			Providers are declared either through the '<rpc-endpoint>' positional argument, which is
+			always the highest priority provider and is named "default", or through the repeatable
+			'--provider' flag, or both. The '--provider' value is '<url>[#<name>]', the provider's
+			name being everything after the last '#' of the value:
+
+			    --provider=https://mainnet.example.com/v1/<api-key>          named "mainnet.example.com", the URL's host
+			    --provider=https://mainnet.example.com/v1/<api-key>#primary  named "primary"
+
+			Provider names must be unique. They identify the provider in the logs and they are what
+			'--headers' uses to send a header to a single provider, through that same '#<name>'
+			suffix, again taken after the last '#' of the value:
+
+			    --headers="X-Api-Key: shared"                  sent to every provider
+			    --headers="Authorization: Bearer xyz#primary"  sent only to the "primary" provider
+
+			Since both suffixes are taken after the last '#', a URL or a header value legitimately
+			ending with '#<something>' is going to be mis-parsed, there is no escaping syntax. A
+			'#' anywhere else in the value, like in the middle of an API key, is left alone.
+
+			Examples:
+
+			    fireeth tools poller optimism https://endpoint.example.com 1000
+
+			    fireeth tools poller optimism 1000 \
+			      --provider=https://primary.example.com/v1/key#primary \
+			      --provider=https://fallback.example.com/key#fallback \
+			      --headers="Authorization: Bearer token#fallback"
+		`),
 	}
 
 	cmd.PersistentFlags().Uint("parallel-workers", 20, "number of parallel workers to fetch transaction receipts")
 	cmd.PersistentFlags().Uint("block-fetch-batch-size", 1, "number of blocks to fetch (and serialize) in parallel")
-	cmd.PersistentFlags().StringSliceP("headers", "H", nil, "headers to send with each request (ex: '-H \"key1: value1\" -H \"key2: value2\"')")
+	cmd.PersistentFlags().StringArray("provider", nil, "RPC provider to poll blocks from, in the form '<url>[#<name>]', repeat the flag to declare multiple providers, the flag order being the priority order (first one preferred, next ones used as fallback). The name defaults to the URL's host and is what identifies the provider in logs and in '--headers'. It is taken after the last '#' of the value")
+	cmd.PersistentFlags().StringSliceP("headers", "H", nil, "headers to send with each request, either 'Key: Value' to send it to every provider or 'Key: Value#<provider-name>' to send it only to that provider (ex: '-H \"key1: value1\" -H \"Authorization: Bearer xyz#fallback\"'). The provider name is taken after the last '#' of the value, so a header value legitimately ending with '#<something>' is going to be mis-parsed, there is no escaping syntax")
+	cmd.PersistentFlags().Duration("providers-failback-interval", 10*time.Minute, "interval at which the declared provider order is re-preferred, moving polling back to the preferred provider after a transient error moved it to a fallback one. Set to 0 to stick to the fallback provider until the process is restarted")
 	cmd.PersistentFlags().Bool("allow-empty-receipts-on-block-0", false, "whether to accept empty receipts on block 0, filling them with 'empty' transactions (useful for TRON-EVM)")
 
 	cmd.AddCommand(newOptimismPollerCmd(logger, tracer))
@@ -40,9 +74,9 @@ func newPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 func newOptimismPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	// identical as generic-evm for now
 	cmd := &cobra.Command{
-		Use:   "optimism <rpc-endpoint> <first-streamable-block>",
+		Use:   "optimism [<rpc-endpoint>] <first-streamable-block>",
 		Short: "poll blocks from optimism rpc",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.RangeArgs(1, 2),
 		RunE:  pollerRunE(logger, tracer),
 	}
 	cmd.Flags().Duration("interval-between-fetch", 0, "interval between fetch")
@@ -53,9 +87,9 @@ func newOptimismPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Comm
 func newArbOnePollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	// identical as generic-evm for now
 	cmd := &cobra.Command{
-		Use:   "arb-one <rpc-endpoint> <first-streamable-block>",
+		Use:   "arb-one [<rpc-endpoint>] <first-streamable-block>",
 		Short: "poll blocks from arb-one rpc",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.RangeArgs(1, 2),
 		RunE:  pollerRunE(logger, tracer),
 	}
 	cmd.Flags().Duration("interval-between-fetch", 0, "interval between fetch")
@@ -65,9 +99,9 @@ func newArbOnePollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Comman
 }
 func newGenericEVMPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "generic-evm <rpc-endpoint> <first-streamable-block>",
+		Use:   "generic-evm [<rpc-endpoint>] <first-streamable-block>",
 		Short: "poll blocks from a generic EVM RPC endpoint",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.RangeArgs(1, 2),
 		RunE:  pollerRunE(logger, tracer),
 	}
 	cmd.Flags().Duration("interval-between-fetch", 0, "interval between fetch")
@@ -78,7 +112,7 @@ func newGenericEVMPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Co
 
 func newFirehoseTracerPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "firehose-tracer-api <rpc-endpoint> <first-streamable-block>",
+		Use:   "firehose-tracer-api [<rpc-endpoint>] <first-streamable-block>",
 		Short: "poll blocks using debug_traceFirehoseBlockByNumber",
 		Long: cli.Dedent(`
 			This poller connects to a Firehose-enabled RPC endpoint and fetches
@@ -89,7 +123,7 @@ func newFirehoseTracerPollerCmd(logger *zap.Logger, tracer logging.Tracer) *cobr
 			*Experimental*: This tool is not production-ready. Intended for development
 			and debugging purposes only.
 		`),
-		Args: cobra.ExactArgs(2),
+		Args: cobra.RangeArgs(1, 2),
 		RunE: pollerRunEForTracer(logger),
 	}
 	cmd.Flags().Duration("interval-between-fetch", 0, "interval between fetch")
@@ -108,43 +142,72 @@ func pollerRunEForTracer(logger *zap.Logger) func(cmd *cobra.Command, args []str
 
 func pollerRunEInternal(logger *zap.Logger, tracer logging.Tracer, useTracer bool) firecore.CommandExecutor {
 	return func(cmd *cobra.Command, args []string) (err error) {
-		rpcEndpoint := args[0]
+		// Two forms are accepted, '<rpc-endpoint> <first-streamable-block>' where the endpoint
+		// becomes the highest priority provider, and '<first-streamable-block>' alone in which
+		// case all providers come from the '--provider' flag.
+		var rpcEndpoint string
+		firstStreamableBlockArg := args[0]
+		if len(args) == 2 {
+			rpcEndpoint, firstStreamableBlockArg = args[0], args[1]
+		}
+
 		//dataDir := cmd.Flag("data-dir").Value.String()
 		fetchInterval := sflags.MustGetDuration(cmd, "interval-between-fetch")
 		parallelWorkers := sflags.MustGetInt(cmd, "parallel-workers")
 		blockFetchBatchSize := sflags.MustGetInt(cmd, "block-fetch-batch-size")
 		maxBlockFetchDuration := sflags.MustGetDuration(cmd, "max-block-fetch-duration")
+		failbackInterval := sflags.MustGetDuration(cmd, "providers-failback-interval")
 
 		dataDir := sflags.MustGetString(cmd, "data-dir")
 		stateDir := path.Join(dataDir, "poller-state")
 
-		firstStreamableBlock, err := strconv.ParseUint(args[1], 10, 64)
+		firstStreamableBlock, err := strconv.ParseUint(firstStreamableBlockArg, 10, 64)
 		if err != nil {
-			return fmt.Errorf("unable to parse first streamable block %d: %w", firstStreamableBlock, err)
+			return fmt.Errorf("unable to parse first streamable block %q: %w", firstStreamableBlockArg, err)
+		}
+
+		providers, err := rpcprovider.Parse(rpcEndpoint, sflags.MustGetStringArray(cmd, "provider"), sflags.MustGetStringSlice(cmd, "headers"))
+		if err != nil {
+			return err
+		}
+
+		redactedProviders := make([]string, len(providers))
+		for i, provider := range providers {
+			redactedProviders[i] = provider.Name + "=" + provider.RedactedURL()
 		}
 
 		logger.Info("launching firehose-ethereum poller",
-			zap.String("rpc_endpoint", rpcEndpoint),
+			zap.Strings("rpc_providers", redactedProviders),
 			zap.String("data_dir", dataDir),
 			zap.String("state_dir", stateDir),
 			zap.Duration("fetch_interval", fetchInterval),
 			zap.Duration("max_block_fetch_duration", maxBlockFetchDuration),
+			zap.Duration("providers_failback_interval", failbackInterval),
 			zap.Uint64("first_streamable_block", firstStreamableBlock),
 			zap.Int("block_fetch_batch_size", blockFetchBatchSize),
 		)
 		rpcClients := firecorerpc.NewClients[*rpc.Client](maxBlockFetchDuration, firecorerpc.NewStickyRollingStrategy[*rpc.Client](), logger)
 
-		var opts []rpc.Option
-		for _, headerStr := range sflags.MustGetStringSlice(cmd, "headers") {
-			parts := strings.SplitN(headerStr, ":", 2)
-			if len(parts) == 2 {
-				key := strings.TrimSpace(parts[0])
-				value := strings.TrimSpace(parts[1])
-				opts = append(opts, rpc.WithHttpHeader(key, value))
+		for _, provider := range providers {
+			opts := make([]rpc.Option, len(provider.Headers))
+			for i, header := range provider.Headers {
+				opts[i] = rpc.WithHttpHeader(header.Key, header.Value)
 			}
+
+			rpcClients.AddNamed(rpc.NewClient(provider.URL, opts...), provider.Name)
 		}
 
-		rpcClients.Add(rpc.NewClient(rpcEndpoint, opts...))
+		// The rolling strategy is sticky forever, a single transient error on the preferred provider
+		// moves polling to a fallback one until the process restarts. Periodically re-preferring the
+		// declared order bounds how long we stay on a fallback provider.
+		if failbackInterval > 0 && len(providers) > 1 {
+			go func() {
+				for range time.Tick(failbackInterval) {
+					logger.Debug("re-preferring declared provider order", zap.String("preferred_provider", providers[0].Name))
+					rpcClients.Reset()
+				}
+			}()
+		}
 
 		var fetcher blockpoller.BlockFetcher[*rpc.Client]
 		if useTracer {

--- a/cmd/fireeth/rpcprovider/provider.go
+++ b/cmd/fireeth/rpcprovider/provider.go
@@ -1,0 +1,203 @@
+// Package rpcprovider parses the poller's RPC provider definitions, coming either from the
+// legacy positional <rpc-endpoint> argument or from the repeatable --provider flag, together
+// with the --headers flag which can be either global or scoped to a single provider.
+package rpcprovider
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// DefaultProviderName is the name given to the provider defined through the positional
+// <rpc-endpoint> argument, which is always the highest priority provider.
+const DefaultProviderName = "default"
+
+// redacted is what replaces the parts of an endpoint URL that are likely to hold a credential.
+const redacted = "redacted"
+
+var errEndpointNoHost = errors.New(`endpoint URL has no host, it must be an absolute URL like "https://host/path"`)
+
+// Provider is a single RPC endpoint the poller fetches blocks from. The order of a []Provider
+// is the priority order: the first one is tried first.
+type Provider struct {
+	// Name identifies the provider in logs and errors, it is unique across all providers.
+	Name string
+	// URL is the raw endpoint URL, credentials included, use [Provider.RedactedURL] when logging it.
+	URL string
+	// Headers are the HTTP headers to send with each request to this provider, in flag order.
+	Headers []Header
+}
+
+// Header is a single HTTP header to send to a provider.
+type Header struct {
+	Key   string
+	Value string
+}
+
+// RedactedURL returns the provider's URL with everything that could hold a credential removed,
+// keeping only the scheme and the host. It is what should be printed in logs, API keys are
+// commonly embedded in the path (`https://host/v1/<api-key>`) or in the query string.
+func (p Provider) RedactedURL() string {
+	u, err := url.Parse(p.URL)
+	if err != nil {
+		return "(unparsable endpoint URL)"
+	}
+
+	if u.User != nil {
+		u.User = url.User(redacted)
+	}
+
+	if u.Path != "" && u.Path != "/" {
+		u.Path = "/" + redacted
+		u.RawPath = ""
+	}
+
+	if u.RawQuery != "" {
+		u.RawQuery = redacted
+	}
+
+	u.Fragment = ""
+	u.RawFragment = ""
+
+	return u.String()
+}
+
+// Parse turns the poller's endpoint inputs into an ordered list of providers.
+//
+// The positionalEndpoint, when non-empty, always becomes the first (highest priority) provider
+// and is named [DefaultProviderName]. Each providerFlags entry is `<url>[#<name>]`, defaulting
+// the name to the URL's host, and each headerFlags entry is `<key>: <value>[#<provider-name>]`,
+// applying to every provider when it carries no provider name.
+//
+// Both `#` separators are found by splitting on the **last** `#` of the flag's value.
+func Parse(positionalEndpoint string, providerFlags []string, headerFlags []string) ([]Provider, error) {
+	providers, err := parseProviders(positionalEndpoint, providerFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := applyHeaders(providers, headerFlags); err != nil {
+		return nil, err
+	}
+
+	return providers, nil
+}
+
+func parseProviders(positionalEndpoint string, providerFlags []string) ([]Provider, error) {
+	var providers []Provider
+
+	if positionalEndpoint != "" {
+		if _, err := parseEndpoint(positionalEndpoint); err != nil {
+			return nil, fmt.Errorf("invalid <rpc-endpoint> argument %q: %w", positionalEndpoint, err)
+		}
+
+		providers = append(providers, Provider{Name: DefaultProviderName, URL: positionalEndpoint})
+	}
+
+	for _, flag := range providerFlags {
+		endpoint, name, named := splitOnLastHash(flag)
+		if endpoint == "" {
+			return nil, fmt.Errorf("invalid --provider %q: empty endpoint URL", flag)
+		}
+
+		if named && name == "" {
+			return nil, fmt.Errorf("invalid --provider %q: empty provider name after '#'", flag)
+		}
+
+		endpointURL, err := parseEndpoint(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --provider %q: %w", flag, err)
+		}
+
+		if !named {
+			name = endpointURL.Host
+		}
+
+		if slices.ContainsFunc(providers, func(p Provider) bool { return p.Name == name }) {
+			return nil, fmt.Errorf("invalid --provider %q: provider name %q is already used by another provider", flag, name)
+		}
+
+		providers = append(providers, Provider{Name: name, URL: endpoint})
+	}
+
+	if len(providers) == 0 {
+		return nil, errors.New("no RPC provider defined, provide one as the <rpc-endpoint> positional argument or through at least one --provider flag")
+	}
+
+	return providers, nil
+}
+
+func applyHeaders(providers []Provider, headerFlags []string) error {
+	for _, flag := range headerFlags {
+		definition, providerName, scoped := splitOnLastHash(flag)
+		if scoped && providerName == "" {
+			return fmt.Errorf("invalid --headers %q: empty provider name after '#'", flag)
+		}
+
+		key, value, found := strings.Cut(definition, ":")
+		if !found {
+			return fmt.Errorf(`invalid --headers %q: expected format "Key: Value" or "Key: Value#<provider-name>"`, flag)
+		}
+
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		if key == "" {
+			return fmt.Errorf("invalid --headers %q: empty header key", flag)
+		}
+
+		header := Header{Key: key, Value: value}
+
+		if !scoped {
+			for i := range providers {
+				providers[i].Headers = append(providers[i].Headers, header)
+			}
+			continue
+		}
+
+		index := slices.IndexFunc(providers, func(p Provider) bool { return p.Name == providerName })
+		if index < 0 {
+			return fmt.Errorf("invalid --headers %q: no provider named %q, known providers are %v", flag, providerName, Names(providers))
+		}
+
+		providers[index].Headers = append(providers[index].Headers, header)
+	}
+
+	return nil
+}
+
+// Names returns the provider names, in priority order.
+func Names(providers []Provider) []string {
+	names := make([]string, len(providers))
+	for i, provider := range providers {
+		names[i] = provider.Name
+	}
+
+	return names
+}
+
+func parseEndpoint(endpoint string) (*url.URL, error) {
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse endpoint URL: %w", err)
+	}
+
+	if endpointURL.Host == "" {
+		return nil, errEndpointNoHost
+	}
+
+	return endpointURL, nil
+}
+
+// splitOnLastHash splits `value#suffix` on its **last** '#'. A value legitimately ending with
+// `#something` is going to be mis-split, this is a known and accepted limitation, there is no
+// escaping syntax.
+func splitOnLastHash(in string) (value string, suffix string, found bool) {
+	index := strings.LastIndex(in, "#")
+	if index < 0 {
+		return in, "", false
+	}
+
+	return in[:index], in[index+1:], true
+}

--- a/cmd/fireeth/rpcprovider/provider_test.go
+++ b/cmd/fireeth/rpcprovider/provider_test.go
@@ -1,0 +1,251 @@
+package rpcprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_positionalEndpointOnly(t *testing.T) {
+	providers, err := Parse("https://primary.example.com/v1/abcd", nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Provider{
+		{Name: "default", URL: "https://primary.example.com/v1/abcd"},
+	}, providers)
+}
+
+func TestParse_providerFlagsOnly(t *testing.T) {
+	providers, err := Parse("", []string{
+		"https://primary.example.com/v1/abcd#primary",
+		"https://fallback.example.com/efgh#fallback",
+	}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Provider{
+		{Name: "primary", URL: "https://primary.example.com/v1/abcd"},
+		{Name: "fallback", URL: "https://fallback.example.com/efgh"},
+	}, providers)
+}
+
+func TestParse_providerNameDefaultsToHost(t *testing.T) {
+	providers, err := Parse("", []string{
+		"https://primary.example.com/v1/abcd",
+		"http://localhost:8545",
+	}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Provider{
+		{Name: "primary.example.com", URL: "https://primary.example.com/v1/abcd"},
+		{Name: "localhost:8545", URL: "http://localhost:8545"},
+	}, providers)
+}
+
+// Some providers embed the API key in the middle of the path, followed by more path segments
+// (Avalanche C-Chain style endpoints are a common example). The URL must go through untouched,
+// trailing slash included, and the name must default to the host only.
+func TestParse_apiKeyInTheMiddleOfThePath(t *testing.T) {
+	const endpointURL = "https://node.avalanche-mainnet.example.com/6eebf479d18c8fa23ffad796d82c9f148aaac6f4/ext/bc/C/rpc/"
+
+	providers, err := Parse(endpointURL, []string{endpointURL + "#avalanche"}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Provider{
+		{Name: "default", URL: endpointURL},
+		{Name: "avalanche", URL: endpointURL},
+	}, providers)
+
+	providers, err = Parse("", []string{endpointURL}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Provider{
+		{Name: "node.avalanche-mainnet.example.com", URL: endpointURL},
+	}, providers)
+}
+
+func TestParse_positionalIsAlwaysPriorityZero(t *testing.T) {
+	providers, err := Parse("https://primary.example.com", []string{
+		"https://a.example.com#a",
+		"https://b.example.com#b",
+	}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"default", "a", "b"}, names(providers))
+}
+
+func TestParse_noProviderAtAll(t *testing.T) {
+	_, err := Parse("", nil, nil)
+	assert.EqualError(t, err, `no RPC provider defined, provide one as the <rpc-endpoint> positional argument or through at least one --provider flag`)
+}
+
+func TestParse_duplicateProviderNames(t *testing.T) {
+	_, err := Parse("", []string{
+		"https://a.example.com#same",
+		"https://b.example.com#same",
+	}, nil)
+	assert.EqualError(t, err, `invalid --provider "https://b.example.com#same": provider name "same" is already used by another provider`)
+}
+
+func TestParse_duplicateProviderNamesAgainstPositional(t *testing.T) {
+	_, err := Parse("https://a.example.com", []string{"https://b.example.com#default"}, nil)
+	assert.EqualError(t, err, `invalid --provider "https://b.example.com#default": provider name "default" is already used by another provider`)
+}
+
+func TestParse_duplicateProviderNamesFromDefaultedHost(t *testing.T) {
+	_, err := Parse("", []string{
+		"https://a.example.com/v1/first",
+		"https://a.example.com/v1/second",
+	}, nil)
+	assert.EqualError(t, err, `invalid --provider "https://a.example.com/v1/second": provider name "a.example.com" is already used by another provider`)
+}
+
+func TestParse_emptyProviderName(t *testing.T) {
+	_, err := Parse("", []string{"https://a.example.com#"}, nil)
+	assert.EqualError(t, err, `invalid --provider "https://a.example.com#": empty provider name after '#'`)
+}
+
+func TestParse_emptyProviderURL(t *testing.T) {
+	_, err := Parse("", []string{"#primary"}, nil)
+	assert.EqualError(t, err, `invalid --provider "#primary": empty endpoint URL`)
+}
+
+func TestParse_invalidProviderURL(t *testing.T) {
+	_, err := Parse("", []string{"://nope#primary"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid --provider "://nope#primary": unable to parse endpoint URL`)
+}
+
+func TestParse_providerURLWithoutHost(t *testing.T) {
+	_, err := Parse("", []string{"localhost:8545"}, nil)
+	assert.EqualError(t, err, `invalid --provider "localhost:8545": endpoint URL has no host, it must be an absolute URL like "https://host/path"`)
+}
+
+func TestParse_positionalURLIsValidated(t *testing.T) {
+	_, err := Parse("localhost:8545", nil, nil)
+	assert.EqualError(t, err, `invalid <rpc-endpoint> argument "localhost:8545": endpoint URL has no host, it must be an absolute URL like "https://host/path"`)
+}
+
+func TestParse_globalHeadersAppliedToEveryProvider(t *testing.T) {
+	providers, err := Parse("", []string{
+		"https://a.example.com#a",
+		"https://b.example.com#b",
+	}, []string{
+		"X-Api-Key: secret",
+		"User-Agent: fireeth",
+	})
+	require.NoError(t, err)
+
+	expected := []Header{{Key: "X-Api-Key", Value: "secret"}, {Key: "User-Agent", Value: "fireeth"}}
+	assert.Equal(t, []Provider{
+		{Name: "a", URL: "https://a.example.com", Headers: expected},
+		{Name: "b", URL: "https://b.example.com", Headers: expected},
+	}, providers)
+}
+
+func TestParse_scopedHeaderAppliedToSingleProvider(t *testing.T) {
+	providers, err := Parse("", []string{
+		"https://a.example.com#a",
+		"https://b.example.com#b",
+	}, []string{
+		"X-Global: everywhere",
+		"Authorization: Bearer token-b#b",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Provider{
+		{Name: "a", URL: "https://a.example.com", Headers: []Header{
+			{Key: "X-Global", Value: "everywhere"},
+		}},
+		{Name: "b", URL: "https://b.example.com", Headers: []Header{
+			{Key: "X-Global", Value: "everywhere"},
+			{Key: "Authorization", Value: "Bearer token-b"},
+		}},
+	}, providers)
+}
+
+func TestParse_headerScopedToPositionalDefaultProvider(t *testing.T) {
+	providers, err := Parse("https://a.example.com", []string{"https://b.example.com#b"}, []string{
+		"X-Api-Key: only-default#default",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Header{{Key: "X-Api-Key", Value: "only-default"}}, providers[0].Headers)
+	assert.Empty(t, providers[1].Headers)
+}
+
+func TestParse_headerValueKeepsColonsAndIsTrimmed(t *testing.T) {
+	providers, err := Parse("https://a.example.com", nil, []string{
+		"  X-Trace  :   a:b:c  ",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Header{{Key: "X-Trace", Value: "a:b:c"}}, providers[0].Headers)
+}
+
+func TestParse_headerSplitsOnLastHash(t *testing.T) {
+	providers, err := Parse("", []string{"https://a.example.com#a"}, []string{
+		"Authorization: Bearer abc#def#a",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Header{{Key: "Authorization", Value: "Bearer abc#def"}}, providers[0].Headers)
+}
+
+func TestParse_headerForUnknownProvider(t *testing.T) {
+	_, err := Parse("", []string{"https://a.example.com#a"}, []string{
+		"Authorization: Bearer token#fallback",
+	})
+	assert.EqualError(t, err, `invalid --headers "Authorization: Bearer token#fallback": no provider named "fallback", known providers are [a]`)
+}
+
+func TestParse_headerWithoutColon(t *testing.T) {
+	_, err := Parse("https://a.example.com", nil, []string{"NotAHeader"})
+	assert.EqualError(t, err, `invalid --headers "NotAHeader": expected format "Key: Value" or "Key: Value#<provider-name>"`)
+}
+
+func TestParse_headerWithEmptyKey(t *testing.T) {
+	_, err := Parse("https://a.example.com", nil, []string{" : value"})
+	assert.EqualError(t, err, `invalid --headers " : value": empty header key`)
+}
+
+func TestParse_headerWithEmptyProviderName(t *testing.T) {
+	_, err := Parse("https://a.example.com", nil, []string{"X-Key: value#"})
+	assert.EqualError(t, err, `invalid --headers "X-Key: value#": empty provider name after '#'`)
+}
+
+func TestRedactedURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{"no path", "https://eth.example.com", "https://eth.example.com"},
+		{"root path", "https://eth.example.com/", "https://eth.example.com/"},
+		{"api key in path", "https://primary.example.com/v1/secret-key", "https://primary.example.com/redacted"},
+		{"api key in query", "https://eth.example.com?apikey=secret", "https://eth.example.com?redacted"},
+		{
+			"api key in the middle of the path",
+			"https://node.avalanche-mainnet.example.com/6eebf479d18c8fa23ffad796d82c9f148aaac6f4/ext/bc/C/rpc/",
+			"https://node.avalanche-mainnet.example.com/redacted",
+		},
+		{"path and query", "https://eth.example.com/v1/key?apikey=secret", "https://eth.example.com/redacted?redacted"},
+		{"basic auth", "https://user:password@eth.example.com/v1/key", "https://redacted@eth.example.com/redacted"},
+		{"fragment", "https://eth.example.com/v1/key#frag", "https://eth.example.com/redacted"},
+		{"unparsable", "://nope", "(unparsable endpoint URL)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Provider{URL: tt.in}.RedactedURL())
+		})
+	}
+}
+
+func names(providers []Provider) []string {
+	out := make([]string, len(providers))
+	for i, provider := range providers {
+		out[i] = provider.Name
+	}
+	return out
+}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.16.2-0.20260801030423-c65db5476957
+	github.com/streamingfast/firehose-core v1.16.2-0.20260804031358-9750cd1901c3
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437

--- a/go.sum
+++ b/go.sum
@@ -2318,6 +2318,8 @@ github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dD
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
 github.com/streamingfast/firehose-core v1.16.2-0.20260801030423-c65db5476957 h1:xRt/Bog04P2DdFUdXRT9XO3/H/yjjFrcK3VjrrOrkjQ=
 github.com/streamingfast/firehose-core v1.16.2-0.20260801030423-c65db5476957/go.mod h1:idCuCuUrpvQAfzEgTTV9tkkMuevu/+Tj4RrnpQB4sBE=
+github.com/streamingfast/firehose-core v1.16.2-0.20260804031358-9750cd1901c3 h1:EXBj8P1kqVol2CfJiDmfC1U4S14ikPZhDrgsYq3Tvqs=
+github.com/streamingfast/firehose-core v1.16.2-0.20260804031358-9750cd1901c3/go.mod h1:idCuCuUrpvQAfzEgTTV9tkkMuevu/+Tj4RrnpQB4sBE=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=


### PR DESCRIPTION
## Why

The poller could only ever talk to a single RPC endpoint. `firecorerpc.NewClients` supports N clients, but only the positional `<rpc-endpoint>` argument was ever added to the pool, so there was no way to declare a fallback provider. A comma-separated endpoint doesn't work either — it goes to `url.Parse` verbatim and fails.

we need a fallback provider for the `aval-mainnet` Firehose reader, which today runs `fireeth tools poller optimism <provider1-url> 39337890`.

## What

- **`--provider=<url>[#<name>]`**, repeatable, flag order = priority order. Name defaults to the URL host, must be unique.
- **`--headers="K: V#<name>"`** scopes a header to one provider. Without `#`, it still applies to every provider, so existing invocations are unchanged.
- Both suffixes split on the **last** `#`. A value legitimately ending in `#something` is mis-parsed — documented in the help, no escaping syntax by design.
- **`<rpc-endpoint>` positional is now optional** (`RangeArgs(1, 2)`). When given it is always the priority-0 provider, named `default`, and `--provider` flags follow it.
- **`--providers-failback-interval`** (default `10m`) periodically re-prefers the declared order.
- Startup errors, never silent drops: duplicate provider name, header scoped to an unknown provider, no provider at all, malformed header.

Parsing lives in its own package `cmd/fireeth/rpcprovider` with 29 unit tests covering every case above.

### Why failback, and why 10m

`StickyRollingStrategy` is sticky *forever*: `reset()` only zeroes `usedClientCount` and `next()` then returns the last client used. One transient error on the primary moved the poller to the fallback permanently until pod restart — in our case, paying for full-time Provider2 polling after a momentary Provider1 blip.

10m caps that at ~10 minutes of fallback billing per incident. The cost of a failback attempt is one failed block fetch that immediately rolls to the next provider, so at 6/hour against a genuinely-down primary it's noise. `0` restores the previous behavior.

## Deliberate behavior changes

1. The `launching firehose-ethereum poller` log line no longer prints endpoint URLs. It reports `rpc_providers: ["provider1=https://provider1.com/redacted"]` — scheme and host kept, path/query/userinfo redacted, since API keys live in the path.
2. A malformed `--headers` entry (no `:`, or empty key) is now a startup error instead of being silently ignored, which used to surface later as an auth rejection that looked like a credential problem.

Known gap: the underlying eth-go transport error still embeds the full URL (`Post "https://host/v1/<key>": dial tcp ...`), so a key can still reach the logs through an RPC error. Fixing that needs an eth-go change.

## Dependency

Requires firehose-core `AddNamed` / `Names` / `Reset` plus per-provider error attribution (streamingfast/firehose-core#198). Bumped to `v1.16.2-0.20260804031358-9750cd1901c3`.

## Verification

`go build ./...` and `go test ./...` green. Exercised against the real binary:

```
launching firehose-ethereum poller {"rpc_providers": ["provider1=https://127.0.0.1:1/redacted", "provider2=https://127.0.0.1:2/redacted"], ...}
rolling to next RPC provider {"from_provider": "provider1", "to_provider": "provider2", "error": ...}
... "2 errors occurred: * provider \"provider1\": ... * provider \"provider2\": ..."
```

- `tools poller optimism <url> <block>` back-compat confirmed unchanged.
- `--providers-failback-interval=2s` fired 3 re-prefers over 7s.
- Every startup error path checked against the binary.

New invocation for two providers:

```
fireeth tools poller optimism 39337890 \
  --provider=<provider1-url>#provider1 \
  --provider=<provider2-url>#provider2
```