### PR TITLE
Bump substreams to v1.21.0 and firehose-core to v1.17.0, release v2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md)
 for instructions to keep up to date.
 
-## Unreleased
+## v2.20.0
+
+### Added
+
+- New `--substreams-tier2-segment-stall-timeout` flag (default `10m`) on `substreams-tier2`: a segment is now killed when it stops processing blocks for that long, the deadline resetting on every block processed. See the `substreams` bump below for why this replaces the fixed execution budget as the primary guard.
 
 ### Changed
+
+- **Operators** the default of `--substreams-tier2-segment-execution-timeout` moves from `1h` to `4h`. It is now only an absolute backstop, the new `--substreams-tier2-segment-stall-timeout` being the guard that actually kills wedged segments. If you pinned the flag to a value of your own, raise it or drop the override, otherwise expensive-but-healthy segments keep being killed.
+
+- Bumped `firehose-core` to [v1.17.0](https://github.com/streamingfast/firehose-core/releases/tag/v1.17.0):
+
+  - RPC: `rpc.Clients` now tracks a provider name per client (`AddNamed`, `Names()`), failed attempts are attributed to their provider in the returned error (`provider "<name>": <error>`), and each roll to another provider is logged at `warn` with `from_provider`/`to_provider`. A given `from -> to` roll only warns again after 30s have elapsed, so a permanently down provider does not warn on every single call.
+
+  - RPC: new `rpc.Clients.Reset()` bringing the rolling strategy back to the pool's declared order, so the next call goes to the primary provider again. Without it, a `StickyRollingStrategy` that rolled to a fallback after a single transient error stayed on that fallback until the process restarted.
+
+  - RPC: fixed a data race where `rpc.Sort` read the clients pool without holding the lock, and fixed a client added to the pool during a `Sort` round being silently dropped.
+
+  - `fireeth tools substreams logs connection`: explicitly passing `--logs=false` now skips the final `Logs` section altogether, printing neither the prompt nor the Cloud Logging console link. Omitting the flag keeps the previous behavior (prompt, falling back on the console link).
+
+- Bumped `substreams` to [v1.21.0](https://github.com/streamingfast/substreams/releases/tag/v1.21.0):
+
+  - Server: tier2 now aborts a segment when it **stops making progress** rather than when it exceeds a fixed time budget. The new stall timeout (10 minutes by default, `--substreams-tier2-segment-stall-timeout`) resets on every block processed, and the pre-existing segment execution timeout (`--substreams-tier2-segment-execution-timeout`) is kept only as an absolute backstop, its default raised from 60 minutes to 4 hours.
+
+    The old fixed budget was fatal to expensive-but-healthy workloads: a segment making thousands of `eth_call` per block could take slightly longer than 60 minutes while still advancing block by block, get killed, and — since a killed segment is never cached — have its retry redo the same work and hit the same wall. Such a request could never complete, no matter how many times it reconnected. A stalled segment is still killed promptly, and since a single block is already bounded by the block execution timeout (`--substreams-block-execution-timeout`, 3 minutes by default), the stall timeout cannot be tripped by one legitimately slow block.
+
+    The `request active for a long time` log gained a `since_last_progress` field, and a segment killed for stalling now reports `request stalled, no block progress` instead of `request active for too long`.
+
+  - Server: new `substreams_undo_signal_distance_blocks` prometheus histogram, observing how many blocks each `BlockUndoSignal` sent to clients reverts, labeled by `source` (`reorg` when a fork is seen while streaming, `cursor_resolution` when the cursor of an incoming request points to a block that was reorged out). Its `_count` gives the total number of undo signals sent; subtracting the `le="5"` bucket from it gives the number of large ones. Undo signals reverting more than 5 blocks are also logged as a warning with `trace_id`, `head`, `revert_up_to`, `distance` and, on the `cursor_resolution` path, the client `cursor`.
+
+  - Server: tier2 no longer logs `tls: first record does not look like a TLS handshake` errors from plain-HTTP health probes / load balancers hitting a TLS port (same suppress list as the existing EOF and connection-reset handshake noise).
+
+  - Server: a tier1 shutdown happening while a request was still in its parallel backprocessing phase was reported to the client as `Internal` instead of `Unavailable`, so clients did not see the reconnect signal during a tier1 rollout.
 
 - Substreams RPC calls (`eth_call` and `eth_getBalance`) now reuse their HTTP connections instead of opening a new one for every batch.
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.16.2-0.20260804204118-b682ff2aa9e1
+	github.com/streamingfast/firehose-core v1.17.0
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,12 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.16.2-0.20260801030423-c65db5476957
+	github.com/streamingfast/firehose-core v1.16.2-0.20260804204118-b682ff2aa9e1
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.20.4-0.20260801025548-ba603250f40f
+	github.com/streamingfast/substreams v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -2316,8 +2316,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.16.2-0.20260804204118-b682ff2aa9e1 h1:ORA5NH/JTndAjqpIgliYzV4VdePuTTbl+/WFFb4spdY=
-github.com/streamingfast/firehose-core v1.16.2-0.20260804204118-b682ff2aa9e1/go.mod h1:AVyTBHM5Bi/eI/j3Qo1sn0NR6J3IOMptvHBkMWjjyCA=
+github.com/streamingfast/firehose-core v1.17.0 h1:tO+rnM/zjjotguSjiRha2ISYB6E5bPrtCFV48U+gq8M=
+github.com/streamingfast/firehose-core v1.17.0/go.mod h1:AVyTBHM5Bi/eI/j3Qo1sn0NR6J3IOMptvHBkMWjjyCA=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=

--- a/go.sum
+++ b/go.sum
@@ -2316,8 +2316,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.16.2-0.20260801030423-c65db5476957 h1:xRt/Bog04P2DdFUdXRT9XO3/H/yjjFrcK3VjrrOrkjQ=
-github.com/streamingfast/firehose-core v1.16.2-0.20260801030423-c65db5476957/go.mod h1:idCuCuUrpvQAfzEgTTV9tkkMuevu/+Tj4RrnpQB4sBE=
+github.com/streamingfast/firehose-core v1.16.2-0.20260804204118-b682ff2aa9e1 h1:ORA5NH/JTndAjqpIgliYzV4VdePuTTbl+/WFFb4spdY=
+github.com/streamingfast/firehose-core v1.16.2-0.20260804204118-b682ff2aa9e1/go.mod h1:AVyTBHM5Bi/eI/j3Qo1sn0NR6J3IOMptvHBkMWjjyCA=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=
@@ -2347,8 +2347,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.20.4-0.20260801025548-ba603250f40f h1:U5jj7c/QFxpoPgEwt6FJJ0eps5r2kw/7zgH7bifddAw=
-github.com/streamingfast/substreams v1.20.4-0.20260801025548-ba603250f40f/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
+github.com/streamingfast/substreams v1.21.0 h1:NZrFw5IMOFUgM1uBMxicwNYtlJ+yppF7REFJuEg8hbg=
+github.com/streamingfast/substreams v1.21.0/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Cuts **v2.20.0** (minor), bumping:

- `substreams` → [v1.21.0](https://github.com/streamingfast/substreams/releases/tag/v1.21.0)
- `firehose-core` → [v1.17.0](https://github.com/streamingfast/firehose-core/releases/tag/v1.17.0)

### Operator-visible changes

- New `--substreams-tier2-segment-stall-timeout` flag (default `10m`): tier2 now kills a segment that stops processing blocks, instead of one that merely takes long.
- `--substreams-tier2-segment-execution-timeout` default moves from `1h` to `4h`, becoming an absolute backstop only. **Deployments pinning this flag should raise it or drop the override**, otherwise expensive-but-healthy segments keep being killed.
- New `substreams_undo_signal_distance_blocks` histogram, plus a warning log for undo signals reverting more than 5 blocks.
- tier2 stops logging `tls: first record does not look like a TLS handshake` from plain-HTTP health probes.
- tier1 rollouts now correctly report `Unavailable` (not `Internal`) to clients still in parallel backprocessing.
- `fireeth tools substreams logs connection --logs=false` now skips the `Logs` section entirely.
- RPC client pool: named providers, provider-attributed errors, sampled roll logs, and two `rpc.Sort` fixes (data race, dropped client).

### `tools poller` multiple RPC providers

Merged from #194 and released here.

- New repeatable `--provider=<url>[#<name>]`, flag order being the priority order: first is preferred, the next ones are fallback. The `<rpc-endpoint>` positional is now optional and, when given, is always the priority-0 provider named `default`.
- New `--providers-failback-interval` (default `10m`) periodically re-prefers the declared order. The poller's rolling strategy is sticky forever, so a single transient error on the preferred provider used to move polling to a fallback until the process restarted — for a paid fallback endpoint, that meant paying for it full-time after a momentary blip. `0` restores the previous behavior.
- `--headers` entries can be scoped to one provider with the same `#<name>` suffix. Entries without a `#` still apply to every provider.
- The `launching firehose-ethereum poller` log line no longer prints endpoint URLs, reporting `rpc_providers: ["primary=https://primary.example.com/redacted"]` instead, since API keys commonly live in the path.

**Two `--headers` behavior changes operators should check before rolling this out:**

- `--headers` no longer splits its value on commas. It declares a single header and is repeated for more than one. Passing several headers in one comma-separated value no longer works. Conversely, a header with a comma in its value (`-H "Accept-Encoding: gzip, deflate"`) now works instead of being silently truncated.
- A malformed `--headers` entry (no `:`, or an empty key) is now a startup error instead of being silently ignored, which used to surface later as an auth rejection that looked like a credential problem.

### Merge notes

The pending `Unreleased` entries on `develop` — Substreams RPC connection reuse, and the `tools poller` work from #194 — are folded into this release. The `go.mod` conflict against develop resolved to the `firehose-core v1.17.0` tag, which supersedes the pseudo-version #194 depended on and carries the same `AddNamed`/`Names`/`Reset` API.

`go build ./...` and `go test ./...` pass, and the poller binary was exercised against the merged tree with two providers, a comma-bearing header and a provider-scoped header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
