### PR TITLE
Add withdrawals compare ignore, drop TOOLS_/OPSTACK_ from compare env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md)
 for instructions to keep up to date.
 
+## Unreleased
+
+### Added
+
+- Block comparison: new `FIREETH_COMPARE_IGNORE_WITHDRAWALS=true` which removes every trace of beacon chain withdrawals from both sides before comparing: the `withdrawals` list, the header's `withdrawals_root` and the `REASON_WITHDRAWAL` balance changes, the ordinals of the remaining elements being shifted down accordingly.
+
+### Changed
+
+- The block comparison environment variables lose their `TOOLS_` prefix, `FIREETH_TOOLS_COMPARE_IGNORE_<X>` becoming `FIREETH_COMPARE_IGNORE_<X>`. They are not specific to `fireeth tools compare-blocks`: the reader node running in test mode (`--reader-node-test-mode`) sanitizes the blocks it diffs against production with the very same code, so they apply there too. The old names keep working:
+
+  | New name                                              | Deprecated name                                              |
+  | ----------------------------------------------------- | ------------------------------------------------------------ |
+  | `FIREETH_COMPARE_IGNORE_ORDINALS`                     | `FIREETH_TOOLS_COMPARE_IGNORE_ORDINALS`                      |
+  | `FIREETH_COMPARE_IGNORE_GAS`                          | `FIREETH_TOOLS_COMPARE_IGNORE_GAS`                           |
+  | `FIREETH_COMPARE_IGNORE_KECCAK`                       | `FIREETH_TOOLS_COMPARE_IGNORE_KECCAK`                        |
+  | `FIREETH_COMPARE_IGNORE_NOOP_CODE_CHANGES`            | `FIREETH_TOOLS_COMPARE_IGNORE_NOOP_CODE_CHANGES`             |
+  | `FIREETH_COMPARE_IGNORE_REVERTED_CALL_STORAGE_CHANGES` | `FIREETH_TOOLS_COMPARE_IGNORE_REVERTED_CALL_STORAGE_CHANGES` |
+  | `FIREETH_COMPARE_IGNORE_SYSTEM_CALLS_ORDER`           | `FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_CALLS_ORDER`    |
+  | `FIREETH_COMPARE_IGNORE_SYSTEM_CALL_GAS_LIMIT`        | `FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_GAS_LIMIT`      |
+
+  The last two also lose their `OPSTACK_` part, because nothing about them is OP-Stack specific. The `0xffff...fffe` caller they key on is the standard system address used by EIP-4788 (beacon roots), EIP-2935 (block hashes) and EIP-7002/7251 (requests), so those system calls exist on Ethereum mainnet since Cancun.
+
+  The `30000000` vs `31566720` system call gas limit difference that `FIREETH_COMPARE_IGNORE_SYSTEM_CALL_GAS_LIMIT` normalizes is not a chain behavior either, it is a client difference visible on every chain: recent `revm` versions (hence reth) set `SYSTEM_CALL_GAS_LIMIT = 30_000_000 + SSTORE_SET_BYTES * CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL` = `31566720` (EIP-8037) for every system call, ungated by the fork it is meant for (Glamsterdam, not activated on any network yet), while geth keeps giving them `30_000_000`. The gas limit of a system call not being consensus visible, this only ever shows up when comparing traces.
+
 ## v2.20.0
 
 ### Added

--- a/cmd/fireeth/tools_sanitizer.go
+++ b/cmd/fireeth/tools_sanitizer.go
@@ -11,21 +11,43 @@ import (
 	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
 )
 
-var ignoreOrdinals = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_ORDINALS") == "true"
-var ignoreOPStackSystemCallsOrder = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_CALLS_ORDER") == "true"
-var ignoreGas = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_GAS") == "true"
-var ignoreNoopCodeChanges = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_NOOP_CODE_CHANGES") == "true"
-var ignoreKeccak = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_KECCAK") == "true"
-var ignoreRevertedCallStorageChanges = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_REVERTED_CALL_STORAGE_CHANGES") == "true"
-var ignoreOPStackSystemGasLimit = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_GAS_LIMIT") == "true"
-var ignoreWithdrawals = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_WITHDRAWALS") == "true"
+// The sanitizer below is used both by 'fireeth tools compare-blocks' and by the reader node
+// running in test mode ('--reader-node-test-mode'), hence the chain-wide 'FIREETH_COMPARE_'
+// prefix of those environment variables.
+var ignoreOrdinals = boolEnv("FIREETH_COMPARE_IGNORE_ORDINALS", "FIREETH_TOOLS_COMPARE_IGNORE_ORDINALS")
+var ignoreSystemCallsOrder = boolEnv("FIREETH_COMPARE_IGNORE_SYSTEM_CALLS_ORDER", "FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_CALLS_ORDER")
+var ignoreGas = boolEnv("FIREETH_COMPARE_IGNORE_GAS", "FIREETH_TOOLS_COMPARE_IGNORE_GAS")
+var ignoreNoopCodeChanges = boolEnv("FIREETH_COMPARE_IGNORE_NOOP_CODE_CHANGES", "FIREETH_TOOLS_COMPARE_IGNORE_NOOP_CODE_CHANGES")
+var ignoreKeccak = boolEnv("FIREETH_COMPARE_IGNORE_KECCAK", "FIREETH_TOOLS_COMPARE_IGNORE_KECCAK")
+var ignoreRevertedCallStorageChanges = boolEnv("FIREETH_COMPARE_IGNORE_REVERTED_CALL_STORAGE_CHANGES", "FIREETH_TOOLS_COMPARE_IGNORE_REVERTED_CALL_STORAGE_CHANGES")
+var ignoreSystemCallGasLimit = boolEnv("FIREETH_COMPARE_IGNORE_SYSTEM_CALL_GAS_LIMIT", "FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_GAS_LIMIT")
+var ignoreWithdrawals = boolEnv("FIREETH_COMPARE_IGNORE_WITHDRAWALS")
 
-// opStackSystemCaller is the well-known caller (0xffff...fffe) used for OP-Stack system transactions.
-var opStackSystemCaller = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}
+// boolEnv returns true if any of the given environment variables is set to "true", the
+// first name is the current one, the others are deprecated aliases kept for compatibility.
+func boolEnv(names ...string) bool {
+	for _, name := range names {
+		if os.Getenv(name) == "true" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// systemCaller is the well-known system address (0xffff...fffe) used as the caller of system
+// calls (EIP-4788 beacon roots, EIP-2935 block hashes, EIP-7002/7251 requests, OP-Stack system
+// transactions). It is not chain-specific.
+var systemCaller = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}
 
 const (
-	opStackSystemGasLimitOld = 30000000
-	opStackSystemGasLimitNew = 31566720
+	// systemCallGasLimitGeth is the gas limit geth gives to system calls.
+	systemCallGasLimitGeth = 30000000
+
+	// systemCallGasLimitRevm is the gas limit recent revm versions give to system calls, on every
+	// chain and every fork: 30_000_000 + SSTORE_SET_BYTES(64) * CPSB_GLAMSTERDAM(1530) *
+	// SYSTEM_MAX_SSTORES_PER_CALL(16), see revm-handler's SYSTEM_CALL_GAS_LIMIT (EIP-8037).
+	systemCallGasLimitRevm = 31566720
 )
 
 func SanitizeEthereumBlockForCompare(block *pbbstream.Block) *pbbstream.Block {
@@ -76,18 +98,18 @@ func SanitizeEthereumBlockForCompare(block *pbbstream.Block) *pbbstream.Block {
 		removeWithdrawalsFromEthereumBlock(ethBlock)
 	}
 
-	if ignoreOPStackSystemGasLimit {
+	if ignoreSystemCallGasLimit {
 		for _, call := range ethBlock.SystemCalls {
-			normalizeOPStackSystemGasLimit(call)
+			normalizeSystemCallGasLimit(call)
 		}
 		for _, tx := range ethBlock.TransactionTraces {
 			for _, call := range tx.Calls {
-				normalizeOPStackSystemGasLimit(call)
+				normalizeSystemCallGasLimit(call)
 			}
 		}
 	}
 
-	if ignoreOPStackSystemCallsOrder {
+	if ignoreSystemCallsOrder {
 		// reorder system calls by using all the fields as sorting keys
 		sort.Slice(ethBlock.SystemCalls, func(i, j int) bool {
 			si, sj := ethBlock.SystemCalls[i], ethBlock.SystemCalls[j]
@@ -183,8 +205,8 @@ func SanitizeEthereumBlockForCompare(block *pbbstream.Block) *pbbstream.Block {
 	return out
 }
 
-func normalizeOPStackSystemGasLimit(call *pbeth.Call) {
-	if call.GasLimit == opStackSystemGasLimitOld && bytes.Equal(call.Caller, opStackSystemCaller) {
-		call.GasLimit = opStackSystemGasLimitNew
+func normalizeSystemCallGasLimit(call *pbeth.Call) {
+	if call.GasLimit == systemCallGasLimitGeth && bytes.Equal(call.Caller, systemCaller) {
+		call.GasLimit = systemCallGasLimitRevm
 	}
 }

--- a/cmd/fireeth/tools_sanitizer.go
+++ b/cmd/fireeth/tools_sanitizer.go
@@ -18,6 +18,7 @@ var ignoreNoopCodeChanges = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_NOOP_CODE_CH
 var ignoreKeccak = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_KECCAK") == "true"
 var ignoreRevertedCallStorageChanges = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_REVERTED_CALL_STORAGE_CHANGES") == "true"
 var ignoreOPStackSystemGasLimit = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_GAS_LIMIT") == "true"
+var ignoreWithdrawals = os.Getenv("FIREETH_TOOLS_COMPARE_IGNORE_WITHDRAWALS") == "true"
 
 // opStackSystemCaller is the well-known caller (0xffff...fffe) used for OP-Stack system transactions.
 var opStackSystemCaller = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}
@@ -70,6 +71,9 @@ func SanitizeEthereumBlockForCompare(block *pbbstream.Block) *pbbstream.Block {
 	}
 	if ignoreRevertedCallStorageChanges {
 		removeRevertedCallStorageChangesFromEthereumBlock(ethBlock)
+	}
+	if ignoreWithdrawals {
+		removeWithdrawalsFromEthereumBlock(ethBlock)
 	}
 
 	if ignoreOPStackSystemGasLimit {

--- a/cmd/fireeth/tools_sanitizer.go
+++ b/cmd/fireeth/tools_sanitizer.go
@@ -13,7 +13,8 @@ import (
 
 // The sanitizer below is used both by 'fireeth tools compare-blocks' and by the reader node
 // running in test mode ('--reader-node-test-mode'), hence the chain-wide 'FIREETH_COMPARE_'
-// prefix of those environment variables.
+// prefix of those environment variables. The deprecated names carrying an 'OPSTACK_' part are
+// kept for compatibility only, none of the sanitizations is OP-Stack specific.
 var ignoreOrdinals = boolEnv("FIREETH_COMPARE_IGNORE_ORDINALS", "FIREETH_TOOLS_COMPARE_IGNORE_ORDINALS")
 var ignoreSystemCallsOrder = boolEnv("FIREETH_COMPARE_IGNORE_SYSTEM_CALLS_ORDER", "FIREETH_TOOLS_COMPARE_IGNORE_OPSTACK_SYSTEM_CALLS_ORDER")
 var ignoreGas = boolEnv("FIREETH_COMPARE_IGNORE_GAS", "FIREETH_TOOLS_COMPARE_IGNORE_GAS")
@@ -35,9 +36,9 @@ func boolEnv(names ...string) bool {
 	return false
 }
 
-// systemCaller is the well-known system address (0xffff...fffe) used as the caller of system
-// calls (EIP-4788 beacon roots, EIP-2935 block hashes, EIP-7002/7251 requests, OP-Stack system
-// transactions). It is not chain-specific.
+// systemCaller is the standard system address (0xffff...fffe) used as the caller of system
+// calls (EIP-4788 beacon roots, EIP-2935 block hashes, EIP-7002/7251 requests). Present on
+// every EVM chain running those EIPs, Ethereum mainnet included since Cancun.
 var systemCaller = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}
 
 const (

--- a/cmd/fireeth/tools_sanitizer_withdrawals.go
+++ b/cmd/fireeth/tools_sanitizer_withdrawals.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"slices"
+	"sort"
+
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
+)
+
+// removeWithdrawalsFromEthereumBlock removes all traces of beacon chain withdrawals from
+// the block: the withdrawals list itself, the header's withdrawals root and the block-level
+// balance changes caused by them. Ordinals of the remaining elements are shifted down so
+// blocks produced with and without withdrawals support can be compared.
+func removeWithdrawalsFromEthereumBlock(block *pbeth.Block) {
+	if block == nil {
+		return
+	}
+
+	removedOrdinals := collectRemovedWithdrawalOrdinals(block)
+
+	block.Withdrawals = nil
+	if block.Header != nil {
+		block.Header.WithdrawalsRoot = nil
+	}
+
+	block.BalanceChanges = slices.DeleteFunc(block.BalanceChanges, isWithdrawalBalanceChange)
+	for _, systemCall := range block.SystemCalls {
+		systemCall.BalanceChanges = slices.DeleteFunc(systemCall.BalanceChanges, isWithdrawalBalanceChange)
+	}
+	for _, trace := range block.TransactionTraces {
+		for _, call := range trace.Calls {
+			call.BalanceChanges = slices.DeleteFunc(call.BalanceChanges, isWithdrawalBalanceChange)
+		}
+	}
+
+	shiftBlockOrdinals(block, removedOrdinals)
+}
+
+func isWithdrawalBalanceChange(balanceChange *pbeth.BalanceChange) bool {
+	return balanceChange.GetReason() == pbeth.BalanceChange_REASON_WITHDRAWAL
+}
+
+func collectRemovedWithdrawalOrdinals(block *pbeth.Block) []uint64 {
+	var out []uint64
+	collect := func(balanceChanges []*pbeth.BalanceChange) {
+		for _, balanceChange := range balanceChanges {
+			if isWithdrawalBalanceChange(balanceChange) && balanceChange.Ordinal > 0 {
+				out = append(out, balanceChange.Ordinal)
+			}
+		}
+	}
+
+	collect(block.BalanceChanges)
+	for _, systemCall := range block.SystemCalls {
+		collect(systemCall.BalanceChanges)
+	}
+	for _, trace := range block.TransactionTraces {
+		for _, call := range trace.Calls {
+			collect(call.BalanceChanges)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return slices.Compact(out)
+}

--- a/devel/substreams/substreams.yaml
+++ b/devel/substreams/substreams.yaml
@@ -12,3 +12,4 @@ start:
     substreams-tier1-subrequests-plaintext: true
     substreams-tier1-subrequests-endpoint: :9001
     substreams-tier2-grpc-listen-addr: :9001
+    substreams-rpc-endpoints: http://localhost:8080/


### PR DESCRIPTION
## What

- New `FIREETH_COMPARE_IGNORE_WITHDRAWALS=true`: strips the `withdrawals` list, the header `withdrawals_root` and the `REASON_WITHDRAWAL` balance changes from both sides, shifting the remaining ordinals down.
- All `FIREETH_TOOLS_COMPARE_IGNORE_<X>` vars become `FIREETH_COMPARE_IGNORE_<X>`, old names still honored.
- `..._OPSTACK_SYSTEM_GAS_LIMIT` / `..._OPSTACK_SYSTEM_CALLS_ORDER` also lose their `OPSTACK_` part.

## Why

The `TOOLS_` prefix is wrong: the reader node in test mode (`--reader-node-test-mode`) diffs its blocks against production with the same `SanitizeEthereumBlockForCompare`, so those vars apply there too.

The `OPSTACK_` part is wrong too:

- `0xffff...fffe` is the standard system address (EIP-4788 beacon roots, EIP-2935 block hashes, EIP-7002/7251 requests), so those system calls exist on eth-mainnet since Cancun.
- The `30000000` vs `31566720` gas limit is a client difference, not a chain one: recent revm (hence reth) sets `SYSTEM_CALL_GAS_LIMIT = 30_000_000 + SSTORE_SET_BYTES * CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL` (EIP-8037) for every system call, ungated by the fork it targets (Glamsterdam, live on no network), while geth keeps giving them `30_000_000`. Not consensus visible, only shows up in traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)