### PR TITLE
fix: do not panic when the RPC returns a null block

### DIFF
--- a/blockfetcher/rpc.go
+++ b/blockfetcher/rpc.go
@@ -82,6 +82,17 @@ func (f *BlockFetcher) FetchPBEth(ctx context.Context, rpcClient *rpc.Client, bl
 		return nil, fmt.Errorf("fetching block %d: %w", blockNum, err)
 	}
 
+	// An endpoint that lags behind the head it reported through `eth_blockNumber`, or
+	// that pruned the block, answers with a JSON-RPC `null` result and no error, which
+	// decodes to a nil block. Reporting it lets the caller retry and rotate provider.
+	if rpcBlock == nil {
+		return nil, fmt.Errorf("block %d not found on this endpoint, it is either not available yet or was pruned", blockNum)
+	}
+
+	if rpcBlock.Hash == nil {
+		return nil, fmt.Errorf("block %d was returned without a hash", blockNum)
+	}
+
 	blockHash := eth.Bytes(rpcBlock.Hash.Bytes())
 	var receipts map[string]*rpc.TransactionReceipt
 	var logs map[string][]eth.Log

--- a/blockfetcher/rpc_test.go
+++ b/blockfetcher/rpc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/streamingfast/eth-go/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 var (
@@ -187,4 +188,53 @@ func TestFetchReceipts_BatchSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, batchCalled)
 	require.Len(t, out, 2)
+}
+
+// nullBlockServer answers `eth_blockNumber` with a head above the requested
+// block, then serves a JSON-RPC `null` result for `eth_getBlockByNumber`. This
+// is what a lagging load-balanced endpoint (or one that pruned the block)
+// returns, and it comes back without any JSON-RPC error.
+func nullBlockServer(t *testing.T, blockResult string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buffer := bytes.NewBuffer(nil)
+		_, err := buffer.ReadFrom(r.Body)
+		require.NoError(t, err)
+
+		var req map[string]interface{}
+		err = json.Unmarshal(buffer.Bytes(), &req)
+		require.NoError(t, err)
+
+		switch method := req["method"].(string); method {
+		case "eth_blockNumber":
+			w.Write([]byte(`{"jsonrpc":"2.0","id":"0x1","result":"0xff"}`))
+		case "eth_getBlockByNumber":
+			w.Write([]byte(blockResult))
+		default:
+			t.Fatalf("unexpected method: %s", method)
+		}
+	}))
+}
+
+func TestFetchPBEth_NullBlockIsAnError(t *testing.T) {
+	server := nullBlockServer(t, `{"jsonrpc":"2.0","id":"0x1","result":null}`)
+	defer server.Close()
+
+	fetcher := NewBlockFetcher(0, 0, 2, nil, zap.NewNop())
+
+	block, err := fetcher.FetchPBEth(context.Background(), rpc.NewClient(server.URL), 10)
+	assert.Nil(t, block)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "10")
+}
+
+func TestFetchPBEth_BlockWithoutHashIsAnError(t *testing.T) {
+	server := nullBlockServer(t, `{"jsonrpc":"2.0","id":"0x1","result":{"number":"0xa"}}`)
+	defer server.Close()
+
+	fetcher := NewBlockFetcher(0, 0, 2, nil, zap.NewNop())
+
+	block, err := fetcher.FetchPBEth(context.Background(), rpc.NewClient(server.URL), 10)
+	assert.Nil(t, block)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "10")
 }

--- a/cmd/fireeth/tools_poll_rpc_blocks.go
+++ b/cmd/fireeth/tools_poll_rpc_blocks.go
@@ -80,6 +80,13 @@ func createPollRPCBlocksE(logger *zap.Logger) firecore.CommandExecutor {
 				continue
 			}
 
+			// A `null` result comes back without an error, so retry rather than
+			// dereferencing a nil block.
+			if rpcBlock == nil || rpcBlock.Hash == nil {
+				delay(fmt.Errorf("block %d not available on this endpoint", blockNum))
+				continue
+			}
+
 			receipts, err := blockfetcher.FetchReceipts(ctx, rpcBlock, client, 20, false)
 			if err != nil {
 				delay(fmt.Errorf("fetching receipts for block %d %q: %w", rpcBlock.Number, rpcBlock.Hash.Pretty(), err))


### PR DESCRIPTION
Behind a load balancer, `eth_blockNumber` can be answered by a node that is ahead of the one serving the block fetch, so the poller crashes as soon as it catches up to the head. We hit it often on fast chains we poll.