### PR TITLE
Bump substreams to develop HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ for instructions to keep up to date.
 
   The `30000000` vs `31566720` system call gas limit difference that `FIREETH_COMPARE_IGNORE_SYSTEM_CALL_GAS_LIMIT` normalizes is not a chain behavior either, it is a client difference visible on every chain: recent `revm` versions (hence reth) set `SYSTEM_CALL_GAS_LIMIT = 30_000_000 + SSTORE_SET_BYTES * CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL` = `31566720` (EIP-8037) for every system call, ungated by the fork it is meant for (Glamsterdam, not activated on any network yet), while geth keeps giving them `30_000_000`. The gas limit of a system call not being consensus visible, this only ever shows up when comparing traces.
 
+- Bumped `substreams` to [develop@a6afd34](https://github.com/streamingfast/substreams/commit/a6afd3480e24b7b0048146e68dc18c085365b9b1) (untagged, ahead of `v1.21.0`):
+
+  - Server: `substreams-tier1` now restarts itself when its block hub can no longer link live blocks, instead of serving a frozen head forever. When the live source reconnects after a gap, the hub back-fills the missing blocks from the one-block store; those files are deleted once merged, so a gap outliving that retention could never be linked. The hub then kept ingesting live blocks it could never emit, its ForkDB growing without bound while every request handed off at the frozen head and hung indefinitely — and since the head-block metrics keep tracking the live source, the instance still looked healthy. The relayer has guarded against this for a while, tier1 was left on the disabled default.
+
+  - Server: a tier1 request that is still running now logs a bounded summary of **why it is slow** every 5 minutes: where the blocks the client receives come from, how far each stage got and what its jobs are doing, what the external calls cost, the error that killed the last job, and how long the request spent blocked writing to the consumer. Every rate and delta covers a fixed trailing 5 minutes, so two consecutive lines are always comparable. A short hints list names the likely bottleneck when one is confidently detected — a full cache lead and a throttled scheduler are the steady state of a healthy request, not symptoms, so the consumer is only blamed for time actually spent blocked sending to it.
+
+    To keep those stats meaningful while a block is stuck, tier2 now reports failing and in-flight external calls (count, oldest wait, block held up) every 10 seconds instead of only once they return. An `eth_call` retrying against an unreachable endpoint is a single wasm extension call that can last minutes, which tier1 used to see as an idle job with no metrics until the whole segment gave up.
+
 ## v2.20.0
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.21.0
+	github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -2347,8 +2347,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.21.0 h1:NZrFw5IMOFUgM1uBMxicwNYtlJ+yppF7REFJuEg8hbg=
-github.com/streamingfast/substreams v1.21.0/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
+github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24 h1:G36rHghTrrlVZXGQNuugGUqSMExtsfcUKepQaF8Cj+8=
+github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Pins `substreams` to `develop@a6afd34` (untagged, ahead of `v1.21.0`), picking up two server-side changes:

- **`fix(tier1): restart when the hub can no longer link live blocks`** ([#864](https://github.com/streamingfast/substreams/pull/864)) — a live-source gap that outlives one-block-store retention could never be linked, leaving the hub ingesting live blocks it could never emit: unbounded ForkDB growth, every request hanging at a frozen head, and head-block metrics still looking healthy. tier1 now gives up and restarts, re-bootstrapping from merged blocks.

- **`Log why a substreams request is slow, while it is still running`** ([#863](https://github.com/streamingfast/substreams/pull/863)) — bounded per-request summary every 5 minutes (block sources, stage/job progress, external call cost, last job error, time blocked on the consumer), plus tier2 now reporting failing and in-flight external calls every 10s instead of only on return.

CHANGELOG updated under `Unreleased`. `go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)