### PR TITLE
Bump firehose-core and substreams to latest develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md)
 for instructions to keep up to date.
 
+## Unreleased
+
+### Changed
+
+- Bumped `firehose-core` to [v1.18.1-0.20260826180840-dd23e67e1b50](https://github.com/streamingfast/firehose-core/compare/2d13baafe8f2...dd23e67e1b50) and `substreams` to [v1.22.1-0.20260826153554-edb28d2ecdae](https://github.com/streamingfast/substreams/compare/1cffa6c10a8d...edb28d2ecdae):
+
+  - Server: store snapshots (fullKV files) can now be pruned to save disk space: `substreams-tier1` no longer assumes that a fullKV at block `x` implies that every earlier fullKV still exists. At request start it walks backwards from the first segment needing work, in growing listing windows, until it finds the last block where every store module still has a snapshot, and rebuilds the stores from there. Only snapshots actually seen are reused, and a job is only scheduled once the previous segment of every lower stage is done, so a pruned file is never read. The new `fireeth tools substreams prune-states` command (below) is what does the pruning.
+
+  - Server: a store snapshot deleted while a request that still needs it is running now fails that request with `FailedPrecondition: ... does not exist (it may have been pruned); restart the request` instead of retrying the tier2 job forever. Likewise, a mapper output file deleted after its job completed is re-produced after 30 seconds instead of being waited on forever, and a scheduler deadlock on partials left by an interrupted run (a unit shadowed under one merging a partial from disk) is fixed.
+
+  - Server: the initial store lookup no longer falls back to listing a store's whole history when its last snapshot is far behind: it lists at most a handful of bounded windows.
+
+  - Server: progress messages are sent far less often, the cadence widening with the age of the request — every second for the first minute, every 10 seconds up to 5 minutes, every 30 seconds up to 10 minutes, then every minute — including in the linear phase, which previously sent one every 200ms. Progress messages count as egress like any other response, so a long-running or live request paid for a steady stream of them. `Request.progress_messages_interval_ms` is now honoured (it was validated and then ignored): setting it pins the cadence for the whole request, the 500ms minimum unchanged.
+
+  - Server: `substreams-tier1` now names the usage marker it writes in every module cache folder after the request's plan tier: `last_used_<plan>` (lowercase, e.g. `last_used_pro`), still plain `last_used` when unauthenticated. `fireeth tools substreams purge` reads the plan back from that name to apply a retention per plan.
+
+### Added
+
+- Added `fireeth tools substreams purge <state-url>` which deletes substreams module caches that have not been used recently, reading the `last_used*.zst` markers that `substreams-tier1` refreshes on every request it serves. Retention can be per billing plan (`--retention default=30d,pro=30d,scaling=14d,free=3d`), a module folder being kept as soon as one of its markers is within its own plan's retention. Direct tier1 layouts (`<state-url>/<hash>`, `<state-url>/<tag>/<hash>`) and shared network roots (`<state-url>/<network>/substreams-states/<tag>/<hash>`) are both recognized. Supports `--dry-run`, `--scan-only`, `--keep` glob patterns, `--read-marker-contents` for stores whose objects were copied (which resets last-write times), and `--daemon --interval 12h` for unattended purging. See the `firehose-core` changelog for the full details.
+
+- Added `fireeth tools substreams prune-states <store-url> --keep-every <blocks> --truncate-below-block <block>` to delete intermediate store snapshots (`<end>-<start>.kv` files) of modules still in use, keeping the first snapshot of each `--keep-every`-aligned window. Only snapshots whose end block is at or below `--truncate-below-block` are thinned, the most recent snapshot of each module is always kept, and `--minimum-age` additionally spares recently written ones. `substreams-tier1` rebuilds stores from the last remaining snapshot before the requested block (see the bump above), so pruning trades disk space for reprocessing time. Supports `--dry-run`.
+
+- Added `fireeth tools substreams prune-outputs <store-url> --network <network> --truncate-below-block <block> --minimum-age <age>` to delete execution output files (`<start>-<end>.output` under a module's `outputs/` folder) that are BOTH fully below `--truncate-below-block` AND last modified longer than `--minimum-age` ago, the modification time coming straight out of the listing. Module folders carrying an spkg (directly-queried output modules) are kept untouched unless `--output-module-minimum-age` is set. Supports `--dry-run` and `--force`.
+
 ## v2.21.0
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -19,15 +19,15 @@ require (
 	github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b
 	github.com/streamingfast/derr v0.0.0-20250814163534-bd7407bd89d7
 	github.com/streamingfast/dmetrics v0.0.0-20260819172634-28069dc8018a
-	github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902
+	github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.17.1-0.20260821132013-2d13baafe8f2
+	github.com/streamingfast/firehose-core v1.18.1-0.20260826180840-dd23e67e1b50
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.3-0.20260810132752-360563ac68a9
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.21.1-0.20260820161654-1cffa6c10a8d
+	github.com/streamingfast/substreams v1.22.1-0.20260826153554-edb28d2ecdae
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -2309,8 +2309,8 @@ github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1 h1:keuutoe
 github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1/go.mod h1:vfsE+IinxWwS89Zu7KdQAizkF+INgG9x/7V++Aeum6A=
 github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58 h1:at7VPRhGImEz71Tr7I6Wtql9KSxQhKBAPkCDyuEIO9g=
 github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58/go.mod h1:ldDwFqr20xXyaLhwDm7XlMaf2vvoZNOrjgsMcFJGtrw=
-github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902 h1:vmSOeUk0Q56YLeVuYqYwmQEfPvq6guLbRRuVrWo8j2Y=
-github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902/go.mod h1:TMunfchUOefhTu+X2a81fPMW0F4/cGNNdihXIaChpJI=
+github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c h1:GURTlIajYhrQvk8dIYPLTa9urVaghe8fUCb/V+6qeVk=
+github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c/go.mod h1:TMunfchUOefhTu+X2a81fPMW0F4/cGNNdihXIaChpJI=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9 h1:RaMv0J2e30vQpJiKdWOGB1HObWtJ4/w4vEUkUhTYE+c=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9/go.mod h1:huOJyjMYS6K8upTuxDxaNd+emD65RrXoVBvh8f1/7Ns=
 github.com/streamingfast/dummy-blockchain v1.7.7 h1:9IZk0zmkeqHirSIRSNtbxrl5kRzyoS7kmXGqKuFI2Yc=
@@ -2319,8 +2319,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.17.1-0.20260821132013-2d13baafe8f2 h1:2O/9y/LVF93bmcCaJkM16zZ3SUpo2nF7i+AZAi47uIY=
-github.com/streamingfast/firehose-core v1.17.1-0.20260821132013-2d13baafe8f2/go.mod h1:n7SL4miqqgsASy+4/zg2h25yyXcgCa77t/NHslNrvg8=
+github.com/streamingfast/firehose-core v1.18.1-0.20260826180840-dd23e67e1b50 h1:73J3s8ymCs4Iwat4rDJm5nMmJQRJPuTZ6zt+Q38g8S8=
+github.com/streamingfast/firehose-core v1.18.1-0.20260826180840-dd23e67e1b50/go.mod h1:33qB0wXZh2WiyNgvcgqbTn/IJ5s5H8IdNSbDHfkxWr4=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.3 h1:kFqhWlp5QtkKW9kezee0cqVjZlChEMGqlkrHK+mtj38=
@@ -2348,8 +2348,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.21.1-0.20260820161654-1cffa6c10a8d h1:nPGVt9/BGbCu/IrEeTlA8FERWr26AhKS3DpOvC6heCk=
-github.com/streamingfast/substreams v1.21.1-0.20260820161654-1cffa6c10a8d/go.mod h1:+/sMeDsRhmAvE1tf1nmsZOXkBKlvPk484uzf6ML8JxA=
+github.com/streamingfast/substreams v1.22.1-0.20260826153554-edb28d2ecdae h1:7qdTZCPgyc9o0YMTD+tvp5AH7RBIHql2d1osp1EL5DU=
+github.com/streamingfast/substreams v1.22.1-0.20260826153554-edb28d2ecdae/go.mod h1:+/sMeDsRhmAvE1tf1nmsZOXkBKlvPk484uzf6ML8JxA=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `firehose-core` to [v1.18.1-0.20260826180840-dd23e67e1b50](https://github.com/streamingfast/firehose-core/compare/2d13baafe8f2...dd23e67e1b50) and `substreams` to [v1.22.1-0.20260826153554-edb28d2ecdae](https://github.com/streamingfast/substreams/compare/1cffa6c10a8d...edb28d2ecdae) (both latest develop), pulling in the thin-store work (streamingfast/substreams#901, streamingfast/firehose-core#224, streamingfast/firehose-core#225).

## Server (substreams)

- Store snapshots (fullKV files) can now be pruned: tier1 walks back to the last block where every store module still has a snapshot and rebuilds from there, never reading a pruned file.
- A snapshot deleted under a running request fails it with `FailedPrecondition` instead of retrying forever; a deleted mapper output is re-produced after 30s; a scheduler deadlock on partials left by an interrupted run is fixed.
- Bounded initial store lookup (no more full-history listing when the last snapshot is far behind).
- Progress messages ramp down with request age and `Request.progress_messages_interval_ms` is honoured.
- Usage markers are per plan: `last_used_<plan>`.

## New operator tools (from firehose-core)

- `fireeth tools substreams purge` — delete module caches unused past a per-plan retention, driven by the `last_used*` markers.
- `fireeth tools substreams prune-states` — thin intermediate store snapshots (`--keep-every` windows) below `--truncate-below-block`, optional `--minimum-age`.
- `fireeth tools substreams prune-outputs` — delete output files both fully below `--truncate-below-block` and older than `--minimum-age`; spkg-carrying (directly-queried) modules kept unless `--output-module-minimum-age`.

All support `--dry-run`. Details in the CHANGELOG.
