### PR TITLE
refactor: use slices.Sort for block numbers

### DIFF
--- a/cmd/fireeth/tools_sanitizer_noop_code_changes.go
+++ b/cmd/fireeth/tools_sanitizer_noop_code_changes.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"slices"
-	"sort"
 
 	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
 )
@@ -64,7 +63,7 @@ func collectNoopCodeChangeOrdinals(block *pbeth.Block) []uint64 {
 		return nil
 	}
 
-	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	slices.Sort(out)
 	return slices.Compact(out)
 }
 


### PR DESCRIPTION
## What changed

Replace a natural-order `sort.Slice` callback for block numbers with `slices.Sort`.

## Why

The values already have a natural `uint64` ordering, so a custom index-based comparator is unnecessary. The resulting order is identical.

## Verification

- `go test ./cmd/fireeth/...`