### PR TITLE
Bump firehose-core and substreams to latest develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ for instructions to keep up to date.
 
 ### Changed
 
-- Bumped `firehose-core` to [v1.18.1-0.20260826180840-dd23e67e1b50](https://github.com/streamingfast/firehose-core/compare/2d13baafe8f2...dd23e67e1b50) and `substreams` to [v1.22.1-0.20260826153554-edb28d2ecdae](https://github.com/streamingfast/substreams/compare/1cffa6c10a8d...edb28d2ecdae):
+- Bumped `firehose-core` to [v1.18.1-0.20260902155646-475a571f0fe2](https://github.com/streamingfast/firehose-core/compare/2d13baafe8f2...475a571f0fe2) and `substreams` to [v1.22.1-0.20260902153244-5658911b40ce](https://github.com/streamingfast/substreams/compare/1cffa6c10a8d...5658911b40ce):
 
   - Server: store snapshots (fullKV files) can now be pruned to save disk space: `substreams-tier1` no longer assumes that a fullKV at block `x` implies that every earlier fullKV still exists. At request start it walks backwards from the first segment needing work, in growing listing windows, until it finds the last block where every store module still has a snapshot, and rebuilds the stores from there. Only snapshots actually seen are reused, and a job is only scheduled once the previous segment of every lower stage is done, so a pruned file is never read. The new `fireeth tools substreams prune-states` command (below) is what does the pruning.
 
@@ -20,7 +20,56 @@ for instructions to keep up to date.
 
   - Server: `substreams-tier1` now names the usage marker it writes in every module cache folder after the request's plan tier: `last_used_<plan>` (lowercase, e.g. `last_used_pro`), still plain `last_used` when unauthenticated. `fireeth tools substreams purge` reads the plan back from that name to apply a retention per plan.
 
+  - Server: `substreams-tier1` can now evict requests when its CPU is saturated, which the new `--substreams-tier1-cpu-eviction-*` flags below turn on. When its own cgroup reports CPU usage above 90% of quota for 15 seconds, the instance advertises itself as unready to the load balancer, refuses new requests, waits 8 seconds for the balancer to stop routing to it, then cancels enough of the heaviest requests with `Unavailable` to bring usage back under 75% of quota, so their clients reconnect elsewhere. Development-mode requests are cancelled first, then production requests on live blocks, then production requests still catching up from files — a live request burning two cores keeps burning them for as long as it stays connected, while a catching-up one is spending them on work that ends, and cancelling it throws away the segment progress it would have to redo. New `substreams_tier1_cpu_*` gauges and a `substreams_tier1_evicted_requests_counter` report what it sees and does, in `observe` mode included.
+
+  - Server: new `substreams_tier1_effective_active_requests` gauge, meant to replace `substreams_active_requests` as the horizontal autoscaler input on tier1: the higher of the plain active-request count and the number of requests the CPU budget is being spent at. An instance full of expensive requests, or one holding its CPU down by cancelling requests, then reports itself at capacity and the autoscaler adds instances instead of leaving the count looking healthy.
+
+  - Server: the jobs of a tier1 request now reach the tier2 fleet in the order the client will read their output, instead of racing each other for whatever instance has room. A job asks a per-request launch queue for its turn before every request it sends to a tier2, first attempt and retries alike, and leaves the queue as soon as a tier2 takes it. The queue is ordered by lowest segment first and, within a segment, by highest stage, and only its first 20% may dial at all — at least two jobs, at most 15 — the ones behind sending nothing until a job ahead gets in and moves the window up. A job with nothing queued ahead of it dials immediately, so a fleet with room is paced no differently than before. Without this, the segment the client reads first was no more likely to land than one it would only read minutes later, and a whole request could idle behind a single unlucky low segment. Tunable with `SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT` (default `20`) and `SUBSTREAMS_WORKER_LAUNCH_WINDOW_MAX` (default `15`).
+
+  - Server: a tier2 job that fails is no longer retried on a growing 1s-to-5s backoff of its own; every reason to dial again goes through that same queue, so retries keep the request's reading order. A job that could not get in at all (`ResourceExhausted: service currently overloaded`, a refused connection, `Unavailable: no healthy upstream`) waits 100ms, and a job that got in and then failed waits 5 seconds once — if a tier2 then turns it away for capacity, it is back on the 100ms delay with its failure already counted. The counters that end a hopeless request are unchanged: five failures, or two execution timeouts, and neither is charged for a job that never got in. Tunable with `SUBSTREAMS_WORKER_OVERLOADED_RETRY_DELAY` (default `100ms`, was `300ms`), `SUBSTREAMS_WORKER_FAILED_RETRY_DELAY` (default `5s`) and `SUBSTREAMS_WORKER_OVERLOADED_RETRY_JITTER` (default `100ms`, added to a wait so jobs turned away at the same instant do not redial in lockstep).
+
+  - Server: jobs are now scheduled up to twice the request's worker count ahead of the blocks the client is reading, instead of 1.5 times, so a client that reads slowly still keeps the workers busy.
+
+  - Server: `substreams-tier2` logs far less per segment. A large backfill fans out into tens of thousands of `ProcessRange` calls, each of which was writing about ten `Info` lines with no steady-state diagnostic value, enough to raise an instance's log volume by an order of magnitude. The duplicate auth-info log in the response handler is gone, the store-size and exec-output-file-open logs are now `Debug`, and so are the four shutdown-lifecycle logs of the per-request `dmetering` event emitter, which is opened and torn down on every `ProcessRange` call. The benign `http2: server: error reading preface ...: connection reset by peer` logged whenever a client drops a connection mid-handshake against the plaintext/h2c tier2 port is suppressed, like the existing TLS-handshake ones.
+
+  - The merger now records what a merged-blocks file holds on the object itself, as three custom metadata entries written as it uploads each bundle: `datasize`, the file's size once decompressed, `itemcount`, the number of blocks it holds, and `timestamp`, the time of its first block. A listing then tells what a file holds without reading it. Google Cloud Storage only: no other backend keeps custom object metadata a listing reads back, so elsewhere nothing is written and nothing changes. An annotation that cannot be written never fails the merge.
+
+  - `fireeth tools substreams prune-states` and `prune-outputs` delete much faster: deletions now run on their own `--delete-parallelism` (250 by default) instead of sharing the listing's `--parallelism` (16 and 64), each attempt is bounded at 5s instead of 30s, and a failed deletion is retried once after 50ms instead of four times over 7.5s. A deletion that still fails is reported as before and picked up by the next run.
+
+  - `fireeth tools substreams purge`, `prune-states` and `prune-outputs` all skip any module folder carrying a `DO_NOT_PRUNE` file at its root, next to the `last_used*.zst` markers, and report how many folders that spared.
+
+  - `fireeth tools substreams logs connection` now takes its time range via a `--since` flag instead of a positional `[<date-range>]` argument, matching `logs connections`. Both commands' `--since` now accepts the same grammar as `logs reexec`'s date-range argument: a relative duration (`30m`, `2h`, `1d`, `1w`, `"1 day ago"`, …), a single timestamp, or a `<start>/<end>` range.
+
+  - Dependencies: `google.golang.org/grpc` moves from v1.83.0 to v1.83.1, which clears GHSA-vp52-pcj8-j9qc, reported as HIGH: a peer could exhaust server heap by fragmenting HTTP/2 DATA frames.
+
 ### Added
+
+- New `--substreams-tier1-cpu-eviction-*` flags letting `substreams-tier1` shed requests when its own cgroup reports the CPU saturated. `--substreams-tier1-cpu-eviction-mode` (default `off`, so nothing changes until you set it) selects what it does: `observe` logs the requests it would cancel without cancelling any, `dev-only` cancels development-mode requests, `full` cancels production ones as well. See the bump above for what a round of eviction does.
+
+  The rest are tunables, each defaulting to the value the eviction was designed around:
+
+  | Flag | Default | Meaning |
+  | --- | --- | --- |
+  | `--substreams-tier1-cpu-eviction-threshold` | `0.90` | CPU usage above which the instance counts as overloaded |
+  | `--substreams-tier1-cpu-eviction-sustain` | `15s` | how long that must hold before it acts |
+  | `--substreams-tier1-cpu-eviction-recover-threshold` | `0.75` | CPU usage under which it stops counting as overloaded |
+  | `--substreams-tier1-cpu-eviction-recover-sustain` | `30s` | how long that must hold before it advertises itself as ready again |
+  | `--substreams-tier1-cpu-eviction-target-ratio` | `0.75` | CPU usage a round of eviction cuts down to, which sizes the round |
+  | `--substreams-tier1-cpu-eviction-interval` | `5s` | how often it looks at the CPU |
+  | `--substreams-tier1-cpu-eviction-cooldown` | `15s` | minimum delay between two rounds |
+  | `--substreams-tier1-cpu-eviction-drain-delay` | `8s` | wait between going unready and the first cancellation, covering the load balancer's routing lag |
+  | `--substreams-tier1-cpu-eviction-min-age` | `90s` | requests younger than this are never cancelled, a request being at its most expensive while it loads its stores |
+  | `--substreams-tier1-cpu-eviction-min-burn-cores` | `0.05` | requests burning less than this are never cancelled, since cancelling them frees nothing and costs a reconnect |
+  | `--substreams-tier1-cpu-eviction-quota-cores-override` | `0` | CPU budget to measure usage against instead of the cgroup's `cpu.max` |
+  | `--substreams-tier1-cpu-eviction-nominal-capacity` | `0` | requests a full instance carries; scales the new `substreams_tier1_effective_active_requests` metric and nothing else. `0` takes `--substreams-tier1-active-requests-soft-limit` |
+
+  Thresholds and ratios are fractions of the CPU budget. That budget is the CPU limit the cgroup carries, so an instance running under cgroup v2 with no limit set — `cpu.max` reading `max` — has nothing to compare usage to and logs a warning at startup, leaving the eviction off; `--substreams-tier1-cpu-eviction-quota-cores-override` names the budget yourself in that case, and should stay at or under whatever limit the kernel does enforce, since above it the instance is throttled before the eviction ever fires. Reading the cgroup CPU files failing outright, cgroup v1 included, also logs a warning and leaves the eviction off. Every one of these warnings is only emitted when the mode is not `off`.
+
+- Added `fireeth tools annotate-merged-blocks <gs-store-url>`, which writes the `datasize`, `itemcount` and `timestamp` metadata entries above on merged-blocks files written before the merger did it. Files a previous run already annotated are skipped straight from the listing, so a rerun over a mostly-done store costs one listing and nothing else. `--parallelism` (32 by default) sets how many files are read at once; `--start-block`, `--stop-block`, `--overwrite` and `--dry-run` are supported. Google Cloud Storage only.
+
+- Added `fireeth tools stats-merged-blocks <gs-store-url>`, which reports a merged-blocks store's total compressed and uncompressed size, block count, compression ratio and bytes per block, broken down by month. Nothing is downloaded: every number comes from those three metadata entries, which come back with the listing, so the whole report costs one listing however large the range is. Google Cloud Storage only.
+
+- Added `fireeth tools last-oneblock <oneblocks-store>` which prints the highest block number found among the store's one-block files, as a bare number on stdout, exiting non-zero when the store cannot be listed, holds no one-block file, or a filename does not parse as one.
 
 - Added `fireeth tools substreams purge <state-url>` which deletes substreams module caches that have not been used recently, reading the `last_used*.zst` markers that `substreams-tier1` refreshes on every request it serves. Retention can be per billing plan (`--retention default=30d,pro=30d,scaling=14d,free=3d`), a module folder being kept as soon as one of its markers is within its own plan's retention. Direct tier1 layouts (`<state-url>/<hash>`, `<state-url>/<tag>/<hash>`) and shared network roots (`<state-url>/<network>/substreams-states/<tag>/<hash>`) are both recognized. Supports `--dry-run`, `--scan-only`, `--keep` glob patterns, `--read-marker-contents` for stores whose objects were copied (which resets last-write times), and `--daemon --interval 12h` for unattended purging. See the `firehose-core` changelog for the full details.
 

--- a/go.mod
+++ b/go.mod
@@ -22,18 +22,18 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.18.1-0.20260826180840-dd23e67e1b50
+	github.com/streamingfast/firehose-core v1.18.1-0.20260902155646-475a571f0fe2
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.3-0.20260810132752-360563ac68a9
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.22.1-0.20260826153554-edb28d2ecdae
+	github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.19.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.28.0
-	google.golang.org/grpc v1.83.0
+	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12
 )
 
@@ -203,7 +203,7 @@ require (
 	github.com/streamingfast/dgrpc v0.0.0-20260801042045-4c4ac6a8e41a // indirect
 	github.com/streamingfast/dhammer v0.0.0-20230125192823-c34bbd561bd4 // indirect
 	github.com/streamingfast/diffx v0.0.0-20260428032925-db795b0d8333 // indirect
-	github.com/streamingfast/dmetering v0.0.0-20251027175535-4fd530934b97 // indirect
+	github.com/streamingfast/dmetering v0.0.0-20260901152443-1ff4cd0d617d // indirect
 	github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1 // indirect
 	github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58 // indirect
 	github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2301,8 +2301,8 @@ github.com/streamingfast/dhammer v0.0.0-20230125192823-c34bbd561bd4 h1:HKi8AIkLB
 github.com/streamingfast/dhammer v0.0.0-20230125192823-c34bbd561bd4/go.mod h1:ehPytv7E4rI65iLcrwTes4rNGGqPPiugnH+20nDQyp4=
 github.com/streamingfast/diffx v0.0.0-20260428032925-db795b0d8333 h1:qVO2Khx3BTdLWJSK3XqQhBSzSCwLPJBbZkFFB2hziOU=
 github.com/streamingfast/diffx v0.0.0-20260428032925-db795b0d8333/go.mod h1:8sL0EmNQgDLRtYzr7TXrX6VOoa3wQHwdTUUsok9CtMc=
-github.com/streamingfast/dmetering v0.0.0-20251027175535-4fd530934b97 h1:rXZYa87AFt+kluwe4McC9jZgx/eRNSlOkWQaIj9Yv4w=
-github.com/streamingfast/dmetering v0.0.0-20251027175535-4fd530934b97/go.mod h1:UqWuX3REU/IInBUaymFN2eLjuvz+/0SsoUFjeQlLNyI=
+github.com/streamingfast/dmetering v0.0.0-20260901152443-1ff4cd0d617d h1:qnRdoBuYEZcVIo9uTE/30ZEaoUbUrSoefWNs5sbA1p8=
+github.com/streamingfast/dmetering v0.0.0-20260901152443-1ff4cd0d617d/go.mod h1:UqWuX3REU/IInBUaymFN2eLjuvz+/0SsoUFjeQlLNyI=
 github.com/streamingfast/dmetrics v0.0.0-20260819172634-28069dc8018a h1:PD+qW3nIdQu48+TmjVYGyWpLjFlW3JeYCQ02H1gIU80=
 github.com/streamingfast/dmetrics v0.0.0-20260819172634-28069dc8018a/go.mod h1:JbxEDbzWRG1dHdNIPrYfuPllEkktZMgm40AwVIBENcw=
 github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1 h1:keuutoe31CyL7I/M4XCSLWrm7/rKDbqy+ZgQH7h3BMo=
@@ -2319,8 +2319,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.18.1-0.20260826180840-dd23e67e1b50 h1:73J3s8ymCs4Iwat4rDJm5nMmJQRJPuTZ6zt+Q38g8S8=
-github.com/streamingfast/firehose-core v1.18.1-0.20260826180840-dd23e67e1b50/go.mod h1:33qB0wXZh2WiyNgvcgqbTn/IJ5s5H8IdNSbDHfkxWr4=
+github.com/streamingfast/firehose-core v1.18.1-0.20260902155646-475a571f0fe2 h1:sUk8F/NgyCJVXni4emump4B9CzCG39BSHDBM2RdXdTU=
+github.com/streamingfast/firehose-core v1.18.1-0.20260902155646-475a571f0fe2/go.mod h1:q16ms81IdklvlEAPPPFbMcikLefW1mOVbKmjBJG+lGU=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.3 h1:kFqhWlp5QtkKW9kezee0cqVjZlChEMGqlkrHK+mtj38=
@@ -2348,8 +2348,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.22.1-0.20260826153554-edb28d2ecdae h1:7qdTZCPgyc9o0YMTD+tvp5AH7RBIHql2d1osp1EL5DU=
-github.com/streamingfast/substreams v1.22.1-0.20260826153554-edb28d2ecdae/go.mod h1:+/sMeDsRhmAvE1tf1nmsZOXkBKlvPk484uzf6ML8JxA=
+github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce h1:5vuM/O8gaHjc5M4dH4RCi3XXF13sYt8As+EqoAkqgg8=
+github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=
@@ -3281,8 +3281,8 @@ google.golang.org/grpc v1.62.1/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJai
 google.golang.org/grpc v1.63.0/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
-google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
-google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
The equivalent of https://github.com/streamingfast/firehose-core/pull/233 for `firehose-ethereum`.

Bumps `firehose-core` to `v1.18.1-0.20260902155646-475a571f0fe2` and `substreams` to `v1.22.1-0.20260902153244-5658911b40ce`, both at the head of their `develop`.

The headline is the tier1 CPU eviction: when an instance's own cgroup reports the CPU saturated, it goes unready, waits for the load balancer to drain, and cancels its heaviest requests with `Unavailable` so their clients reconnect elsewhere. The thirteen `--substreams-tier1-cpu-eviction-*` flags that drive it come from `firehose-core` and are now exposed on `fireeth start`; `--substreams-tier1-cpu-eviction-mode` defaults to `off`, so nothing changes on an upgrade until an operator turns it on.

The same bump also carries the tier2 job ordering work (a request's jobs now reach the tier2 fleet in the order the client will read their output, and failed jobs retry through that queue instead of their own backoff), the tier2 per-segment log trim, the merged-blocks object annotations with the `fireeth tools annotate-merged-blocks` and `stats-merged-blocks` commands, `fireeth tools last-oneblock`, and faster `prune-states`/`prune-outputs` deletion. All of it is in the CHANGELOG.

`google.golang.org/grpc` goes from v1.83.0 to v1.83.1 along the way, which clears GHSA-vp52-pcj8-j9qc (HIGH) and supersedes #208.