### PR TITLE
Bump firehose-core and substreams for the eviction metric fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ for instructions to keep up to date.
 
 ### Changed
 
+- Bumped `firehose-core` to [v1.18.1-0.20260902182612-1f4e56f44352](https://github.com/streamingfast/firehose-core/compare/475a571f0fe2...1f4e56f44352) and `substreams` to [v1.22.1-0.20260902182355-0c74c9fac34a](https://github.com/streamingfast/substreams/compare/5658911b40ce...0c74c9fac34a):
+
+  - Server: `substreams_tier1_effective_active_requests` could read below `substreams_active_requests`, the metric it is meant to replace as the horizontal autoscaler input. Requests still setting up were counted by one and not the other, so a tier1 pod with requests queued in setup looked emptier to the autoscaler than it was.
+
 - Bumped `firehose-core` to [v1.18.1-0.20260902155646-475a571f0fe2](https://github.com/streamingfast/firehose-core/compare/2d13baafe8f2...475a571f0fe2) and `substreams` to [v1.22.1-0.20260902153244-5658911b40ce](https://github.com/streamingfast/substreams/compare/1cffa6c10a8d...5658911b40ce):
 
   - Server: store snapshots (fullKV files) can now be pruned to save disk space: `substreams-tier1` no longer assumes that a fullKV at block `x` implies that every earlier fullKV still exists. At request start it walks backwards from the first segment needing work, in growing listing windows, until it finds the last block where every store module still has a snapshot, and rebuilds the stores from there. Only snapshots actually seen are reused, and a job is only scheduled once the previous segment of every lower stage is done, so a pruned file is never read. The new `fireeth tools substreams prune-states` command (below) is what does the pruning.

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,12 @@ require (
 	github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c
 	github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155
 	github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd
-	github.com/streamingfast/firehose-core v1.18.1-0.20260902155646-475a571f0fe2
+	github.com/streamingfast/firehose-core v1.18.1-0.20260902182612-1f4e56f44352
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a
 	github.com/streamingfast/logging v1.2.3-0.20260810132752-360563ac68a9
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce
+	github.com/streamingfast/substreams v1.22.1-0.20260902182355-0c74c9fac34a
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -2319,8 +2319,8 @@ github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155 h1:/rjrpRHJAI
 github.com/streamingfast/eth-go v0.0.0-20260318130445-6d6ccaf27155/go.mod h1:zLYYt0y7LxdB5KDbKg70AuwU48Wq02d8E79tHVkqEzA=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd h1:t5n8dDcgUi7t36Qwxm19K4H2vyOLJfY6MHxTbOvK1z8=
 github.com/streamingfast/firehose v0.1.1-0.20240118135215-dcf04d40bfcd/go.mod h1:du6tys2Q6X2pRQ3JbCziWiy7Y7KrOcl4CSb9uiGsVxA=
-github.com/streamingfast/firehose-core v1.18.1-0.20260902155646-475a571f0fe2 h1:sUk8F/NgyCJVXni4emump4B9CzCG39BSHDBM2RdXdTU=
-github.com/streamingfast/firehose-core v1.18.1-0.20260902155646-475a571f0fe2/go.mod h1:q16ms81IdklvlEAPPPFbMcikLefW1mOVbKmjBJG+lGU=
+github.com/streamingfast/firehose-core v1.18.1-0.20260902182612-1f4e56f44352 h1:0l+6xOvL8Jjbf4ATGXmyyOICztAo4U/Zp04k/WcVhDY=
+github.com/streamingfast/firehose-core v1.18.1-0.20260902182612-1f4e56f44352/go.mod h1:KXwCLsoXZnDktSZBjEXvGfT8XNXSjfqZumQHYHP0CEY=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a h1:/Sk0IWgUB5+FOwjSIfWAfUyW4tPBE7FJPHU8Zde8vqQ=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20260420191823-8b3fce4bf77a/go.mod h1:+ala1ZHyPZy6QZwTw3k7V6tHQ2bXFKP8wIldp2SUJ9Y=
 github.com/streamingfast/firehose-networks v0.2.3 h1:kFqhWlp5QtkKW9kezee0cqVjZlChEMGqlkrHK+mtj38=
@@ -2348,8 +2348,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce h1:5vuM/O8gaHjc5M4dH4RCi3XXF13sYt8As+EqoAkqgg8=
-github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
+github.com/streamingfast/substreams v1.22.1-0.20260902182355-0c74c9fac34a h1:xlA6ixbye4zPdIYUNrCuBkZ8wCPW0E988lTwATQbDgo=
+github.com/streamingfast/substreams v1.22.1-0.20260902182355-0c74c9fac34a/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Picks up streamingfast/firehose-core#236 and streamingfast/substreams#921.

`substreams_tier1_effective_active_requests` could read below `substreams_active_requests`, the metric it is meant to replace as the horizontal autoscaler input, because requests still setting up were counted by one and not the other. A tier1 pod with requests queued in setup looked emptier to the autoscaler than it was.

**Pinned to unmerged commits** (firehose-core `1f4e56f4`, substreams `0c74c9fa`). Re-pin both to develop once they merge, before taking this out of draft.