### PR TITLE
Bump substreams for execout prefetching and scheduler fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ for instructions to keep up to date.
 
 ### Changed
 
-- Bumped `substreams` to [v1.22.1-0.20260902211544-ae5b1131a6b5](https://github.com/streamingfast/substreams/compare/5658911b40ce...ae5b1131a6b5):
+- Bumped `substreams` to [v1.22.1-0.20260903162505-4035f21109ec](https://github.com/streamingfast/substreams/compare/5658911b40ce...4035f21109ec):
 
-  - Server: `substreams-tier1` now downloads the next cached execution output files while it streams the current one to a production-mode client. Before, each 1000-block segment was opened, decompressed and sent before the next one was even requested from the object store. Prefetching is bounded per request to 4 segments ahead and 64 MiB of decompressed data, with no size lookups against the store: the first segment is probed against the whole budget and, if it overflows, prefetching is turned off for that request; otherwise its size decides how many segments download concurrently. Not exposed as flags yet, the defaults apply.
+  - Server: `substreams-tier1` scheduling no longer slows down as a large backprocessing range progresses. Picking the next tier2 job walked every segment between the squasher and the job frontier on every call, re-checking dependencies that could not have changed, so a run over N segments cost O(N²) in scheduling. The scheduler now keeps, per stage, the lowest segment that may still be pending and the highest segment completed so far, and only looks at the handful of segments those point at. On a 3-stage graph with 4 workers and a squasher three times slower than the jobs, scheduling 8000 segments went from 1.18s to 2.7ms, and now grows linearly with the range. Job order is unchanged.
+
+  - Server: `substreams-tier1` now downloads the next cached execution output files while it streams the current one to a production-mode client. Before, each 1000-block segment was opened, decompressed and sent before the next one was even requested from the object store, so every segment paid a full store round trip on the critical path. Prefetching is bounded per request, with no flag to set: at most 4 segments ahead, holding at most 64 MiB of decompressed data. No size is ever asked of the store, the decompressed size of the last downloaded segment being the estimate for the next ones, and a file bigger than the whole budget turns prefetching off for the rest of the request. Missing files are left to the existing retry loop.
+
+  - Server: `substreams-tier1` now sends each batch of cached execution output on its own goroutine, so decoding the next batch overlaps with compressing and writing the current one. At most one batch is being built while one is sent, and a segment is only reported done once every batch is out, so message order is unchanged. Decoding a batch also copies one less time, the item now aliasing the buffer it was read into.
+
+  - Server: `substreams-tier1` writes the `substreams.spkg` and `last_used` cache markers in the background instead of before the pipeline starts, so those object store round trips no longer delay the first block sent. They run detached from the request with a 30 second timeout: the request neither starts nor exits waiting for them, and a client that disconnects early still leaves its usage marker behind.
 
 - Bumped `firehose-core` to [v1.18.1-0.20260902155646-475a571f0fe2](https://github.com/streamingfast/firehose-core/compare/2d13baafe8f2...475a571f0fe2) and `substreams` to [v1.22.1-0.20260902153244-5658911b40ce](https://github.com/streamingfast/substreams/compare/1cffa6c10a8d...5658911b40ce):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ for instructions to keep up to date.
 
 ### Changed
 
+- Bumped `substreams` to [v1.22.1-0.20260902211544-ae5b1131a6b5](https://github.com/streamingfast/substreams/compare/5658911b40ce...ae5b1131a6b5):
+
+  - Server: `substreams-tier1` now downloads the next cached execution output files while it streams the current one to a production-mode client. Before, each 1000-block segment was opened, decompressed and sent before the next one was even requested from the object store. Prefetching is bounded per request to 4 segments ahead and 64 MiB of decompressed data, with no size lookups against the store: the first segment is probed against the whole budget and, if it overflows, prefetching is turned off for that request; otherwise its size decides how many segments download concurrently. Not exposed as flags yet, the defaults apply.
+
 - Bumped `firehose-core` to [v1.18.1-0.20260902155646-475a571f0fe2](https://github.com/streamingfast/firehose-core/compare/2d13baafe8f2...475a571f0fe2) and `substreams` to [v1.22.1-0.20260902153244-5658911b40ce](https://github.com/streamingfast/substreams/compare/1cffa6c10a8d...5658911b40ce):
 
   - Server: store snapshots (fullKV files) can now be pruned to save disk space: `substreams-tier1` no longer assumes that a fullKV at block `x` implies that every earlier fullKV still exists. At request start it walks backwards from the first segment needing work, in growing listing windows, until it finds the last block where every store module still has a snapshot, and rebuilds the stores from there. Only snapshots actually seen are reused, and a job is only scheduled once the previous segment of every lower stage is done, so a pruned file is never read. The new `fireeth tools substreams prune-states` command (below) is what does the pruning.

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/streamingfast/logging v1.2.3-0.20260810132752-360563ac68a9
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.22.1-0.20260902211544-ae5b1131a6b5
+	github.com/streamingfast/substreams v1.22.1-0.20260903162505-4035f21109ec
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/streamingfast/logging v1.2.3-0.20260810132752-360563ac68a9
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/shutter v1.5.0
-	github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce
+	github.com/streamingfast/substreams v1.22.1-0.20260902211544-ae5b1131a6b5
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/tidwall/gjson v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -2348,8 +2348,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.22.1-0.20260902211544-ae5b1131a6b5 h1:zYVS4apg3Cvw+5mA+rRmtIw7yXlJq2vbIZ/nrsPMMmc=
-github.com/streamingfast/substreams v1.22.1-0.20260902211544-ae5b1131a6b5/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
+github.com/streamingfast/substreams v1.22.1-0.20260903162505-4035f21109ec h1:kqkkPgecmnfPQYo1+Njl5aj5AsFj4wwh4TCB0y++/Gg=
+github.com/streamingfast/substreams v1.22.1-0.20260903162505-4035f21109ec/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=

--- a/go.sum
+++ b/go.sum
@@ -2348,8 +2348,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce h1:5vuM/O8gaHjc5M4dH4RCi3XXF13sYt8As+EqoAkqgg8=
-github.com/streamingfast/substreams v1.22.1-0.20260902153244-5658911b40ce/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
+github.com/streamingfast/substreams v1.22.1-0.20260902211544-ae5b1131a6b5 h1:zYVS4apg3Cvw+5mA+rRmtIw7yXlJq2vbIZ/nrsPMMmc=
+github.com/streamingfast/substreams v1.22.1-0.20260902211544-ae5b1131a6b5/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `substreams` to `v1.22.1-0.20260903162505-4035f21109ec` ([compare](https://github.com/streamingfast/substreams/compare/5658911b40ce...4035f21109ec)).

Four `substreams-tier1` changes, all on the path that serves a production-mode client from cached files:

- Picking the next tier2 job walked every segment between the squasher and the job frontier on every call, so a run over N segments cost O(N²) in scheduling. The scheduler now keeps, per stage, the lowest segment that may still be pending and the completed prefix, and only looks at the segments those point at. On 3 stages with 4 workers and a squasher 3x slower than the jobs, scheduling 8000 segments went from 1.18s to 2.7ms. Job order is unchanged.

- Cached execution output files for the next segments now download while the current one is being streamed, instead of each segment paying a full store round trip once the previous one is sent. Bounded per request at 4 segments ahead and 64 MiB of decompressed data, with no flag to set.

- Each batch of cached execution output is sent on its own goroutine, so decoding the next batch overlaps with compressing and writing the current one, and decoding copies the payload one less time. Message order is unchanged.

- The `substreams.spkg` and `last_used` cache markers are written in the background, off the request's critical path, so they no longer delay the first block sent.

No flag or configuration change. Changelog updated.
